### PR TITLE
fix circusd bug obscuring zeromq socket bind error messages

### DIFF
--- a/circus/watcher.py
+++ b/circus/watcher.py
@@ -250,7 +250,8 @@ class Watcher(object):
                     del self.processes[wid]
 
         self.kill_processes(signal.SIGKILL)
-        self.send_msg("stop", {"time": time.time()})
+        if self.evpub_socket is not None:
+            self.send_msg("stop", {"time": time.time()})
         logger.info('%s stopped', self.name)
 
     @util.debuglog


### PR DESCRIPTION
this stack trace occurs when there's another circusd running on the same zeromq endpoint:

<pre>
Traceback (most recent call last):
  File "bin/circusd", line 8, in <module>
    load_entry_point('circus==0.2', 'console_scripts', 'circusd')()
  File "/home/petef/circus/circus/circusd.py", line 178, in main
    arbiter.stop()
  File "/home/petef/circus/circus/arbiter.py", line 111, in stop
    self.stop_watchers(graceful=graceful, stop_alive=True)
  File "/home/petef/circus/circus/arbiter.py", line 217, in stop_watchers
    watcher.stop(graceful=graceful)
  File "/home/petef/circus/circus/util.py", line 178, in _log
    return func(self, *args, **kw)
  File "/home/petef/circus/circus/watcher.py", line 253, in stop
    self.send_msg("stop", {"time": time.time()})
  File "/home/petef/circus/circus/watcher.py", line 77, in send_msg
    if not self.evpub_socket.closed:
AttributeError: 'NoneType' object has no attribute 'closed'
</pre>


in Arbiter.stop(), we should only send_msg() if initialize() was called with an evpub_socket.  with this patch, now a slightly more helpful exception is shown:

<pre>
Traceback (most recent call last):
  File "bin/circusd", line 8, in <module>
    load_entry_point('circus==0.2', 'console_scripts', 'circusd')()
  File "/home/petef/circus/circus/circusd.py", line 176, in main
    arbiter.start()
  File "/home/petef/circus/circus/util.py", line 178, in _log
    return func(self, *args, **kw)
  File "/home/petef/circus/circus/arbiter.py", line 76, in start
    self.initialize()
  File "/home/petef/circus/circus/util.py", line 178, in _log
    return func(self, *args, **kw)
  File "/home/petef/circus/circus/arbiter.py", line 53, in initialize
    self.evpub_socket.bind(self.pubsub_endpoint)
  File "socket.pyx", line 489, in zmq.core.socket.Socket.bind (zmq/core/socket.c:4797)
zmq.core.error.ZMQError: Address already in use
</pre>
