### PR TITLE
fix to_uid, to_gid to catch OverflowError on negative uid/gid which are illegal on linux

### DIFF
--- a/circus/util.py
+++ b/circus/util.py
@@ -135,7 +135,7 @@ def to_uid(name):
         try:
             pwd.getpwuid(name)
             return name
-        except KeyError:
+        except (KeyError, OverflowError):
             raise ValueError("%r isn't a valid user id" % name)
 
     if not isinstance(name, str):
@@ -156,7 +156,7 @@ def to_gid(name):
         try:
             grp.getgrgid(name)
             return name
-        except KeyError:
+        except (KeyError, OverflowError):
             raise ValueError("No such group: %r" % name)
 
     if not isinstance(name, str):


### PR DESCRIPTION
catch OverflowError and a test. Although I could rewrite the existing test_to_uidgid to use getpwall/getgrall to find non-existent uid/gid if preferred
