### PR TITLE
fix --start on circusctl add

### DIFF
--- a/circus/circusctl.py
+++ b/circus/circusctl.py
@@ -166,8 +166,8 @@ class ControllerApp(object):
         client = CircusClient(endpoint=endpoint, timeout=timeout)
         try:
             if isinstance(msg, list):
-                for i, cmd in enumerate(msg):
-                    clm = self._console(client, cmd['command'], opts, cmd['msg'])
+                for i, command in enumerate(msg):
+                    clm = self._console(client, command['cmd'], opts, command['msg'])
                     print("%s: %s" % (i, clm))
             else:
                 print(self._console(client, cmd, opts, msg))

--- a/circus/commands/addwatcher.py
+++ b/circus/commands/addwatcher.py
@@ -56,12 +56,10 @@ class AddWatcher(Command):
 
         msg = self.make_message(name=args[0], cmd=" ".join(args[1:]))
         if opts.get("start", False):
-            return [{'command': self,
-                     'msg': msg,
-                 },
-                    {'command': Start(),
-                     'msg': self.make_message(command="start", name=args[0])
-                 }]
+            return [{'cmd': self,
+                     'msg': msg},
+                    {'cmd': Start(),
+                     'msg': self.make_message(command="start", name=args[0])}]
         return msg
 
     def execute(self, arbiter, props):


### PR DESCRIPTION
When attempting to add a watcher and start it at the same time using:

``` bash
circusctl add --start service "command"
```

It would fail because the command object wasn't being passed to _console. Now this works properly.

I was unsure of how best to add this to the test suite since it was most complicated than just a simple make_message.
