### PR TITLE
test assumed you were on "python"

### DIFF
--- a/circus/tests/test_watcher.py
+++ b/circus/tests/test_watcher.py
@@ -1,6 +1,7 @@
 import time
 import signal
 import sys
+import os
 
 from circus.client import CircusClient, make_message
 from circus.tests.support import TestCircus
@@ -61,4 +62,5 @@ class TestWatcher(TestCircus):
         resp = self.call("stats").get('infos')
         self.assertTrue("test" in resp)
 
-        self.assertEqual(resp['test']['1']['cmdline'], sys.executable.split('/')[-1])
+        self.assertEqual(resp['test']['1']['cmdline'],
+                         sys.executable.split(os.sep)[-1])


### PR DESCRIPTION
On Archlinux python 2.x binary is called python2, this also allows for people who use pypy jython, etc, supposing that worked with circus.
