### PR TITLE
optionnal setproctitle support

### DIFF
--- a/circus/arbiter.py
+++ b/circus/arbiter.py
@@ -11,7 +11,7 @@ from circus.exc import AlreadyExist
 from circus.flapping import Flapping
 from circus import logger
 from circus.watcher import Watcher
-from circus.util import debuglog
+from circus.util import debuglog, _setproctitle
 
 
 class Arbiter(object):
@@ -49,6 +49,9 @@ class Arbiter(object):
 
     @debuglog
     def initialize(self):
+        # set process title
+        _setproctitle("circusd")
+
         # event pub socket
         self.evpub_socket = self.context.socket(zmq.PUB)
         self.evpub_socket.bind(self.pubsub_endpoint)

--- a/circus/util.py
+++ b/circus/util.py
@@ -9,6 +9,15 @@ from functools import wraps
 import sys
 
 from psutil.error import AccessDenied, NoSuchProcess
+
+try:
+    from setproctitle import setproctitle
+    def _setproctitle(title):
+        setproctitle(title)
+except ImportError:
+    def _setproctitle(title):
+        return
+
 from circus import logger
 
 


### PR DESCRIPTION
Allows circus to use setproctitle if installed to set the process name:

```
$ ps ax|grep circusd
92645 s002  S+     0:02.16 circusd
```
