### PR TITLE
Don't poll each process when reaping

### DIFF
--- a/circus/arbiter.py
+++ b/circus/arbiter.py
@@ -2,6 +2,7 @@ import errno
 import logging
 import os
 from threading import Thread
+import time
 
 import zmq
 from zmq.eventloop import ioloop

--- a/circus/util.py
+++ b/circus/util.py
@@ -1,5 +1,4 @@
 from datetime import timedelta
-import errno
 import grp
 import os
 import pwd


### PR DESCRIPTION
Instead of polling each process in each watchers to reap them, only wait
for them using `os.waitpid` in the arbiter. It will remove extra cpu
usage. all tests pass.
