### PR TITLE
Environment Handling is Broken

### DIFF
--- a/circus/config.py
+++ b/circus/config.py
@@ -3,6 +3,7 @@ import os
 import fnmatch
 import sys
 from circus import logger
+from util import parse_env
 
 
 def watcher_defaults():
@@ -191,6 +192,8 @@ def get_config(config_file):
                 elif opt == 'singleton':
                     watcher['singleton'] = dget(section, "singleton", False,
                                                 bool)
+                elif opt == 'env':
+                    watcher['env'] = parse_env(val)
                 else:
                     # freeform
                     watcher[opt] = val

--- a/circus/process.py
+++ b/circus/process.py
@@ -139,7 +139,7 @@ class Process(object):
         logger.debug('args: ' + str(self.args))
 
         current_env = ObjectDict(self.env.copy())
-        current_env.update(os.environ)
+        #current_env.update(os.environ) #This is already applied, in the correct direction with copy_en
 
         format_kwargs = {
             'wid': self.wid, 'shell': self.shell, 'args': self.args,


### PR DESCRIPTION
Discussed this in IRC channel with Alexis.

Basically the environment is not converted from a string using parse_env and even if it was, it would be overwritten inside of the format_args() function.

Alexis said he was going to handle, but I already had it in my own fork so just ignore if not needed.
