### PR TITLE
only call listen() on SOCK_STREAM and SOCK_SEQPACKET sockets

### DIFF
--- a/circus/sockets.py
+++ b/circus/sockets.py
@@ -34,6 +34,7 @@ class CircusSocket(socket.socket):
         super(CircusSocket, self).__init__(family=family, type=type,
                                            proto=proto)
         self.name = name
+        self.socktype = type
         self.host, self.port = addrinfo(host, port)
         self.backlog = backlog
         self.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -49,7 +50,8 @@ class CircusSocket(socket.socket):
             raise
 
         self.setblocking(0)
-        self.listen(self.backlog)
+        if self.socktype in (socket.SOCK_STREAM, socket.SOCK_SEQPACKET):
+            self.listen(self.backlog)
         self.host, self.port = self.getsockname()
         logger.debug('Socket bound at %s:%d - fd: %d' % (self.host, self.port,
                                                          self.fileno()))


### PR DESCRIPTION
circusd isn't working so well with SOCK_DGRAM sockets because listen() can't be called on them; it throws an error and circusd gives up while starting up.  per `man 2 listen`: "The sockfd argument is a file descriptor that refers to a socket of type SOCK_STREAM or SOCK_SEQPACKET."

Here's a small little change that verifies the socket is one of SOCK_STREAM or SOCK_SEQPACKET before calling listen().
