### PR TITLE
Fix for stats on 'unexisting' (read: dead) processes

### DIFF
--- a/circus/commands/stats.py
+++ b/circus/commands/stats.py
@@ -107,6 +107,9 @@ class Stats(Command):
             return {"infos": infos}
 
     def _to_str(self, info):
+        if isinstance(info, basestring):
+            return info
+
         children = info.pop("children", [])
         ret = [_INFOLINE % info]
         for child in children:


### PR DESCRIPTION
There is the unlikely case of the process being dead in which case the info commmand is not returning a dictionary but a string saying exactly that. As of now the `circusctl stats` command fails in such a case with an unhelpful Exception. This minor fix makes it show the string instead. Oh and there is a typo fix in the docs of class in the pull request, too...
