### PR TITLE
Added upstart script and Varnish example to docs

### DIFF
--- a/docs/source/deployment.rst
+++ b/docs/source/deployment.rst
@@ -1,7 +1,23 @@
 Deployment
 ==========
 
+Although the Circus daemon can be managed with the circusd command, it's
+easier to have it start on boot. If your system supports Upstart, you can 
+create this Upstart script in /etc/init/circus.conf:
+
+    start on filesystem and net-device-up IFACE=lo
+
+    stop on shutdown
+
+    respawn
+    exec /usr/local/bin/circusd --log-output /var/log/circus.log \
+                                --pidfile /var/run/circusd.pid \
+                                /etc/circus.ini
+
+This assumes that circus.ini is located at /etc/circus.ini. After 
+rebooting, you can control circusd with the service command:
+
+    $ service circus start/stop/restart
+
 This section will contain recipes to deploy Circus. Until then
 you can look at Pete's Puppet recipe at https://github.com/fetep/puppet-circus
-
-This Puppet recipe also contains an *upstart* script you can reuse.


### PR DESCRIPTION
Added upstart script to deployment docs and a Varnish config example for running the web console with Nginx and websockets to the circushttpd doc, based on http://nathancahill.github.com/circus/
