### PR TITLE
Fixed circus.init, will now stop circusd

### DIFF
--- a/debian/circus.init
+++ b/debian/circus.init
@@ -15,8 +15,8 @@ PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC="circus daemon"
 NAME=circusd
 DAEMON=/usr/bin/circusd
-DAEMON_ARGS="--daemon /etc/circus/circusd.ini"
 PIDFILE=/var/run/$NAME.pid
+DAEMON_ARGS="--daemon --pidfile $PIDFILE /etc/circus/circusd.ini"
 SCRIPTNAME=/etc/init.d/$NAME
 
 # Exit if the package is not installed


### PR DESCRIPTION
start-stop-daemon doesn't create the pidfile, and circusd wasn't. Now it does
