### PR TITLE
fix logger message formating on socket error

### DIFF
--- a/circus/sockets.py
+++ b/circus/sockets.py
@@ -68,7 +68,7 @@ class CircusSocket(socket.socket):
             else:
                 self.bind((self.host, self.port))
         except socket.error:
-            logger.error('Could not bind %s:%d' % self.location)
+            logger.error('Could not bind %s' % self.location)
             raise
 
         self.setblocking(0)


### PR DESCRIPTION
When circus can't bind to a socket, the logger message doesn't have enough arguments to format the string
