### PR TITLE
Add a way to control process respawn.

### DIFF
--- a/circus/config.py
+++ b/circus/config.py
@@ -30,7 +30,9 @@ def watcher_defaults():
         'singleton': False,
         'copy_env': False,
         'copy_path': False,
-        'hooks': dict()}
+        'hooks': dict(),
+        'respawn': True,
+        }
 
 
 _BOOL_STATES = {'1': True, 'yes': True, 'true': True, 'on': True,
@@ -222,6 +224,9 @@ def get_config(config_file):
                         val[1] = to_boolean(val[1])
 
                     watcher['hooks'][hook_name] = val
+
+                elif opt == 'respawn':
+                    watcher['respawn'] = dget(section, "respawn", True, bool)
 
                 else:
                     # freeform

--- a/circus/watcher.py
+++ b/circus/watcher.py
@@ -137,6 +137,9 @@ class Watcher(object):
       found in the configuration file for instance, are passed
       in this mapping -- this can be used by plugins for watcher-specific
       options.
+
+    - **respawn** -- If set to False, the processes handled by a watcher will
+      not be respawned automatically. (default: True)
     """
     def __init__(self, name, cmd, args=None, numprocesses=1, warmup_delay=0.,
                  working_dir=None, shell=False, uid=None, max_retry=5,
@@ -146,8 +149,7 @@ class Watcher(object):
                  stderr_stream=None, stream_backend='thread', priority=0,
                  singleton=False, use_sockets=False, copy_env=False,
                  copy_path=False, max_age=0, max_age_variance=30,
-                 hooks=None,
-                 **options):
+                 hooks=None, respawn=True, **options):
         self.name = name
         self.use_sockets = use_sockets
         self.res_name = name.lower().replace(" ", "_")
@@ -176,6 +178,7 @@ class Watcher(object):
         self.max_age_variance = int(max_age_variance)
         self.ignore_hook_failure = ['before_stop', 'after_stop']
         self.hooks = self._resolve_hooks(hooks)
+        self.respawn = respawn
 
         if singleton and self.numprocesses not in (0, 1):
             raise ValueError("Cannot have %d processes with a singleton "
@@ -344,8 +347,7 @@ class Watcher(object):
 
     @util.debuglog
     def manage_processes(self):
-        """ manage processes
-        """
+        """Manage processes."""
         if self.stopped:
             return
 
@@ -359,7 +361,7 @@ class Watcher(object):
                                        "time": time.time()})
                     self.kill_process(process)
 
-        if len(self.processes) < self.numprocesses:
+        if self.respawn and len(self.processes) < self.numprocesses:
             self.spawn_processes()
 
         processes = self.processes.values()
@@ -374,8 +376,7 @@ class Watcher(object):
 
     @util.debuglog
     def reap_and_manage_processes(self):
-        """Reap & manage processes.
-        """
+        """Reap & manage processes."""
         if self.stopped:
             return
         self.reap_processes()
@@ -533,7 +534,7 @@ class Watcher(object):
 
     @util.debuglog
     def info(self):
-        return dict([(proc.pid, proc.info())\
+        return dict([(proc.pid, proc.info())
                      for proc in self.processes.values()])
 
     @util.debuglog
@@ -624,7 +625,7 @@ class Watcher(object):
 
         self._create_redirectors()
         self.reap_processes()
-        self.manage_processes()
+        self.spawn_processes()
 
         if not self.call_hook('after_start'):
             logger.debug('Aborting startup')

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -72,6 +72,9 @@ circus - single section
     **debug**
         If set to True, all Circus stout/stderr daemons are redirected to circusd
         stdout/stderr (default: False)
+    **respawn**
+        If set to False, the processes handled by a watcher will not be
+        respawned automatically. (default: True)
 
 .. note::
 


### PR DESCRIPTION
The watchers now have a "respawn" option (True per default) which can be set to False. This allows to have processes that are run only once and not respawned automatically.

supersede #162. 
