### PR TITLE
circusctl CLI code and tests cleanup

### DIFF
--- a/circus/circusctl.py
+++ b/circus/circusctl.py
@@ -27,7 +27,6 @@ from circus.util import DEFAULT_ENDPOINT_SUB, DEFAULT_ENDPOINT_DEALER
 
 USAGE = 'circusctl [options] command [args]'
 VERSION = 'circusctl ' + __version__
-PROMPT = '(circusctl) '
 
 
 def prettify(jsonobj, prettify=True):
@@ -170,7 +169,7 @@ class ControllerApp(object):
 
 class CircusCtl(cmd.Cmd, object):
     """CircusCtl tool."""
-    prompt = PROMPT
+    prompt = '(circusctl) '
 
     def __new__(cls, client, commands, *args, **kw):
         """Auto add do and complete methods for all known commands."""
@@ -202,8 +201,6 @@ class CircusCtl(cmd.Cmd, object):
                 try:
                     return cmd.autocomplete(cls.client, *args, **kwargs)
                 except Exception, e:
-                    import traceback
-                    import sys
                     sys.stderr.write(e.message + "\n")
                     traceback.print_exc(file=sys.stderr)
             else:

--- a/circus/tests/test_circusctl.py
+++ b/circus/tests/test_circusctl.py
@@ -3,7 +3,7 @@ import sys
 import shlex
 from unittest import TestCase
 
-from circus.circusctl import USAGE, VERSION, PROMPT
+from circus.circusctl import USAGE, VERSION, CircusCtl
 from circus.tests.support import TestCircus
 
 
@@ -73,12 +73,12 @@ class CLITest(TestCase):
         output = stdout.splitlines()
         self.assertEqual(output[0], VERSION)
         # strip of term escape characters, if any
-        prompt = output[1][-len(PROMPT):]
-        self.assertEqual(prompt, PROMPT)  # prompt start with color code
+        prompt = output[1][-len(CircusCtl.prompt):]
+        self.assertEqual(prompt, CircusCtl.prompt)
 
     def test_cli_help(self):
         stdout, stderr = self.run_ctl('help')
         self.assertEqual(stderr, '')
         prompt = stdout.splitlines()
-        # first two lines are VERSION and PROMPT, followed by a blank line
+        # first two lines are VERSION and prompt, followed by a blank line
         self.assertEqual(prompt[2], "Documented commands (type help <topic>):")


### PR DESCRIPTION
Some cleanup in the CLI feature to:
- fix tests that where failing since calling `circusctl` without command/open now opens the CLI
- add tests for the CLI
- re-add the possibility to call `circusctl --help` which was removed accidentally (I guess?)
- pep8ify

With this commit and an added "unittest2" dependency for tox (in the `tox.ini` file, not added in this commit), all tests runs on my computer, for py2.6 and py2.7
