### PR TITLE
Changes for https://github.com/mozilla-services/circus/issues/182

### DIFF
--- a/circus/tests/test_util.py
+++ b/circus/tests/test_util.py
@@ -52,11 +52,9 @@ class TestUtil(unittest.TestCase):
         self.assertRaises(TypeError, to_gid, None)
 
     def test_negative_uid_gid(self):
-        # OSX allows negative uid/gid and throws KeyError on a miss.  On
-        # x86_64 Linux, the range is (-1, 2^32-1), throwing OverflowError
-        # outside that range, and KeyError on a miss. On 32-bit Linux, all
-        # negative values throw KeyError as do requests for non-existent
-        # uid/gid.
+        # OSX allows negative uid/gid and throws KeyError on a miss. On 
+        # 32-bit and 64-bit Linux, all negative values throw KeyError as do 
+        # requests for non-existent uid/gid.
         def int32(val):
             if (val & 0x80000000):
                 val = -0x100000000 + val
@@ -79,9 +77,9 @@ class TestUtil(unittest.TestCase):
         getgrgid = lambda gid: grp.getgrgid(gid)
 
         self.assertRaises(KeyError, getpwuid, uid_max + 1)
-        self.assertRaises((KeyError, OverflowError), getpwuid, uid_min - 1)
+        self.assertRaises(KeyError, getpwuid, uid_min - 1)
         self.assertRaises(KeyError, getgrgid, gid_max + 1)
-        self.assertRaises((KeyError, OverflowError), getgrgid, gid_min - 1)
+        self.assertRaises(KeyError, getgrgid, gid_min - 1)
 
     def test_replace_gnu_args(self):
         repl = replace_gnu_args

--- a/circus/util.py
+++ b/circus/util.py
@@ -232,7 +232,7 @@ def to_uid(name):
         try:
             pwd.getpwuid(name)
             return name
-        except (KeyError, OverflowError):
+        except KeyError:
             raise ValueError("%r isn't a valid user id" % name)
 
     if not isinstance(name, str):
@@ -253,7 +253,7 @@ def to_gid(name):
         try:
             grp.getgrgid(name)
             return name
-        except (KeyError, OverflowError):
+        except KeyError:
             raise ValueError("No such group: %r" % name)
 
     if not isinstance(name, str):


### PR DESCRIPTION
Removed catches for OverflowError in places where pwd.getpwuid and grp.getgrgid are used.
Clarified test comments.
