### PR TITLE
tests cleanup (factorisation) and fixes by removing sleeps when possible

### DIFF
--- a/circus/tests/test_circusctl.py
+++ b/circus/tests/test_circusctl.py
@@ -19,7 +19,7 @@ def run_ctl(args, stdin=''):
 class CommandlineTest(TestCircus):
     def setUp(self):
         super(CommandlineTest, self).setUp()
-        self._run_circus('circus.tests.test_arbiter.run_dummy')
+        self._run_circus('circus.tests.support.run_process')
 
     def test_help_switch_no_command(self):
         stdout, stderr = run_ctl('--help')

--- a/circus/tests/test_client.py
+++ b/circus/tests/test_client.py
@@ -47,8 +47,8 @@ class TestClient(TestCircus):
         subprocess.call(['ssh-add'])
 
     def _client_test(self, ssh_server):
-        self._run_circus('circus.tests.support.run_process')
-        time.sleep(.5)
+        test_file = self._run_circus('circus.tests.support.run_process')
+        self.assertTrue(poll_for(test_file, 'START'))  # process started
 
         # playing around with the watcher
         client = CircusClient(ssh_server=ssh_server)

--- a/circus/tests/test_runner.py
+++ b/circus/tests/test_runner.py
@@ -1,5 +1,4 @@
-import time
-from circus.tests.support import TestCircus
+from circus.tests.support import TestCircus, poll_for
 
 
 def Dummy(test_file):
@@ -12,10 +11,4 @@ class TestRunner(TestCircus):
 
     def test_dummy(self):
         test_file = self._run_circus('circus.tests.test_runner.Dummy')
-        time.sleep(1.)
-
-        # check that the file has been filled
-        with open(test_file) as f:
-            content = f.read()
-
-        self.assertTrue('.' in content)
+        self.assertTrue(poll_for(test_file, '..........'))

--- a/circus/tests/test_sighandler.py
+++ b/circus/tests/test_sighandler.py
@@ -1,62 +1,17 @@
-from circus.tests.support import TestCircus
-import time
-
-
-class Process(object):
-
-    def __init__(self, testfile):
-        self.testfile = testfile
-        # init signal handling
-        import signal
-        signal.signal(signal.SIGQUIT, self.handle_quit)
-        signal.signal(signal.SIGTERM, self.handle_quit)
-        signal.signal(signal.SIGINT, self.handle_quit)
-        signal.signal(signal.SIGCHLD, self.handle_chld)
-        self.alive = True
-
-    def _write(self, msg):
-        with open(self.testfile, 'a+') as f:
-            f.write(msg)
-
-    def handle_quit(self, *args):
-        if not self.alive:
-            return
-        self.alive = False
-        self._write('QUIT')
-        import sys
-        sys.exit(0)
-
-    def handle_chld(self, *args):
-        self._write('CHLD')
-        return
-
-    def run(self):
-        self._write('START')
-        while self.alive:
-            time.sleep(0.1)
-        self._write('STOP')
-
-
-def run_process(test_file):
-    process = Process(test_file)
-    process.run()
-    return 1
+from circus.tests.support import TestCircus, poll_for
 
 
 class TestSigHandler(TestCircus):
 
     def test_handler(self):
-        test_file = \
-                self._run_circus('circus.tests.test_sighandler.run_process')
-        time.sleep(.5)
+        test_file = self._run_circus(
+            'circus.tests.support.run_process')
+
+        # wait for the process to be started
+        self.assertTrue(poll_for(test_file, 'START'))
 
         # stopping...
         self._stop_runners()
 
-        time.sleep(.1)
-
-        # check that the file has been filled
-        with open(test_file) as f:
-            content = f.read()
-
-        self.assertEqual(content, 'STARTQUIT')
+        # wait for the process to be stopped
+        self.assertTrue(poll_for(test_file, 'QUIT'))

--- a/circus/tests/test_web.py
+++ b/circus/tests/test_web.py
@@ -1,7 +1,6 @@
 import subprocess
 import os
 import sys
-import time
 
 from webtest import TestApp
 
@@ -29,12 +28,11 @@ if GEVENT:
             cmd = '%s -c "from circus import circusd; circusd.main()" %s' % \
                 (sys.executable, cfg)
             self.p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE,
-                                    stderr=subprocess.PIPE)
+                                      stderr=subprocess.PIPE)
 
         def tearDown(self):
             self.p.terminate()
             self.p.kill()
-            time.sleep(0.4)
             TestCircus.tearDown(self)
 
         def test_index(self):


### PR DESCRIPTION
Two main modifications:
- factor out the `run_process` and `Process` in `support.py`
- remove `time.sleep()` wherever possible, and replace it by polling on file/stream to make sure tests won't fail on py26 (slower)
