### PR TITLE
Do not use nose.runner in test_suite anymore

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,9 @@ setup(name='circus',
         "License :: OSI Approved :: Apache Software License",
         "Development Status :: 3 - Alpha"],
       install_requires=install_requires,
-      tests_require=['nose', 'webtest', 'unittest2'],
-      test_suite='nose.collector',
+      setup_requires=install_requires,
+      tests_require=['webtest', 'unittest2'],
+      test_suite='circus.tests',
       entry_points="""
       [console_scripts]
       circusd = circus.circusd:main

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,7 @@
 envlist = py26,py27
 
 [testenv]
-commands = python setup.py test
-deps = nose
-       psutil
-       pyzmq
-       unittest2
+commands = python setup.py develop
+           python setup.py test
+deps = unittest2
        webtest


### PR DESCRIPTION
nose.runner "could" be the issue causing the "addSkip" errors in py26 for travis (using unittest instead of unittest2)
