### PR TITLE
Fix code and tests for PR 310

### DIFF
--- a/circus/process.py
+++ b/circus/process.py
@@ -145,10 +145,10 @@ class Process(object):
             'wid': self.wid, 'shell': self.shell, 'args': self.args,
             'env': current_env, 'working_dir': self.working_dir,
             'uid': self.uid, 'gid': self.gid, 'rlimits': self.rlimits,
-            'executable': self.executable, 'use_fds': self.use_fds,
-            'sockets': self.watcher._get_sockets_fds()}
+            'executable': self.executable, 'use_fds': self.use_fds}
 
         if self.watcher is not None:
+            format_kwargs['sockets'] = self.watcher._get_sockets_fds()
             for option in self.watcher.optnames:
                 if option not in format_kwargs\
                         and hasattr(self.watcher, option):

--- a/circus/tests/test_config.py
+++ b/circus/tests/test_config.py
@@ -4,6 +4,7 @@ from circus.config import get_config
 from circus.watcher import Watcher
 from circus.arbiter import Arbiter
 from circus.process import Process
+from circus.sockets import CircusSocket
 
 HERE = os.path.join(os.path.dirname(__file__))
 
@@ -30,10 +31,10 @@ class TestConfig(unittest.TestCase):
 
         Allow $(circus.sockets.name) to be used in args.
         '''
-        conf = _CONF['issue310']
-        arbiter = Arbiter.load_from_config(conf)
-        arbiter.initialize()
-        watcher = arbiter.watchers[0]
+        conf = get_config(_CONF['issue310'])
+        watcher = Watcher.load_from_config(conf['watchers'][0])
+        socket = CircusSocket.load_from_config(conf['sockets'][0])
+        watcher.initialize(None, {'web': socket}, None)
         process = Process(watcher._process_counter, watcher.cmd,
                     args=watcher.args, working_dir=watcher.working_dir,
                     shell=watcher.shell, uid=watcher.uid, gid=watcher.gid,
@@ -46,7 +47,6 @@ class TestConfig(unittest.TestCase):
 
         self.assertEquals(formatted_args,
                           ['foo', '--fd', str(fd)])
-
 
     def test_issue137(self):
         conf = get_config(_CONF['issue137'])


### PR DESCRIPTION
PR 310 had an issue:
- in the code: did not take into account that watchers could be None
- in the test: using Arbiter.load_config made it use `reload` which monkeypatched ioloop, which breaked subsequent tests
- in the test: using Arbiter.initialize was binding the pubsub endpoint (without closing it), which breaked subsequent tests
