### PR TITLE
don't join from the thread itself, truncate file before restarting

### DIFF
--- a/circus/arbiter.py
+++ b/circus/arbiter.py
@@ -403,4 +403,3 @@ class ThreadedArbiter(Arbiter, Thread):
 
     def stop(self):
         Arbiter.stop(self)
-        self.join()

--- a/circus/tests/support.py
+++ b/circus/tests/support.py
@@ -100,6 +100,7 @@ class TestCircus(unittest.TestCase):
     def _stop_runners(self):
         for arbiter in self.arbiters:
             arbiter.stop()
+            arbiter.join(timeout=5)
         self.arbiters = []
 
     def call(self, cmd, **props):
@@ -171,7 +172,7 @@ def poll_for(filename, needle, timeout=5):
             content = f.read()
         if needle in content:
             return True
-    raise TimeoutException('Timeout while polling %s for %s. Content: %s' % (
+    raise TimeoutException('Timeout polling "%s" for "%s". Content: %s' % (
         filename, needle, content))
 
 

--- a/circus/tests/test_stream.py
+++ b/circus/tests/test_stream.py
@@ -53,9 +53,9 @@ class TestWatcher(TestCircus):
         self.assertTrue(poll_for(self.stderr, 'stderr'))
 
         # restart and make sure streams are still working
-        self.call('restart')
         truncate_file(self.stdout)
         truncate_file(self.stderr)
+        self.call('restart')
 
         # wait for the process to be restarted
         self.assertTrue(poll_for(self.stdout, 'stdout'))


### PR DESCRIPTION
- reorder instructions in test_stream: truncate file before restarting the process writing in it, to be sure no race condition could happen (restarted process writing in the file before it's truncated)
- ThreadedArbiter.join() was called from the thread itself, raising a RuntimeError which didn't break the code, and wasn't visible (because nose captures the logs by default)
