### PR TITLE
small tests reorg and prevent race condition

### DIFF
--- a/circus/exc.py
+++ b/circus/exc.py
@@ -18,7 +18,3 @@ class ArgumentError(Exception):
     """Exception raised when one argument or the number of
     arguments invalid"""
     pass
-
-
-class TimeoutException(Exception):
-    pass

--- a/circus/tests/support.py
+++ b/circus/tests/support.py
@@ -11,7 +11,6 @@ import unittest2 as unittest
 from circus import get_arbiter
 from circus.util import DEFAULT_ENDPOINT_STATS
 from circus.client import CircusClient, make_message
-from circus.exc import TimeoutException
 
 
 def resolve_name(name):
@@ -153,6 +152,10 @@ def run_process(test_file):
     process = Process(test_file)
     process.run()
     return 1
+
+
+class TimeoutException(Exception):
+    pass
 
 
 def poll_for(filename, needle, timeout=5):


### PR DESCRIPTION
- move TimeoutException with the others in exc.py
- reorder instructions in test_stream to prevent possible race condition (empty files before restarting)
