### PR TITLE
Use pyzmq in web-requirements.txt

### DIFF
--- a/circus/web/web-requirements.txt
+++ b/circus/web/web-requirements.txt
@@ -7,4 +7,4 @@ gevent-socketio
 gevent-websocket==0.3.6
 greenlet
 beaker==1.6.3
-git+http://github.com/mozilla-services/gevent-zeromq.git
+pyzmq==2.2.0.1


### PR DESCRIPTION
According to _patch.py the gevent-zeromq fork has been deprecated since the release of pyzmq 2.2.0.1. This patch updates web-requirements.txt to install pyzmq 2.2.0.1 instead of the gevent-zeromq fork (gevent-zeromq currently also fails to install with pip on my Debian Wheezy test machine).
