### PR TITLE
Configuration documentation formatting error

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -17,9 +17,9 @@ Example::
     warmup_delay = 0
     numprocesses = 5
 
-	[env:myprogram]
-	PATH = $PATH:/bin
-	CAKE = lie
+    [env:myprogram]
+    PATH = $PATH:/bin
+    CAKE = lie
 
     # hook
     hooks.before_start = my.hooks.control_redis


### PR DESCRIPTION
Tabs were used instead of spaces for a block, causing it to show up unaligned in the HTML documentation.
