### PR TITLE
Update configuration.rst

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -13,7 +13,7 @@ Example::
 
     [watcher:myprogram]
     cmd = python
-    args = -u myprogram.py $(WID) $(ENV.VAR)
+    args = -u myprogram.py $(circus.wid) $(ENV.VAR)
     warmup_delay = 0
     numprocesses = 5
 


### PR DESCRIPTION
worker ID is not WID anymore but circus.wid
I guess same is true for ENV.VAR (circus.env.var ?) But I cannot find it in the unittest :)
