### PR TITLE
Remove handler on ioloop error.

### DIFF
--- a/circus/stream/redirector.py
+++ b/circus/stream/redirector.py
@@ -14,6 +14,8 @@ class RedirectorHandler(object):
 
     def __call__(self, fd, events):
         if not (events & ioloop.IOLoop.READ):
+            if events == ioloop.IOLoop.ERROR:
+                self.redirector.remove_redirection(self.pipe)
             return
         try:
             data = os.read(fd, self.redirector.buffer)


### PR DESCRIPTION
This happens frequently when the other end of the pipe dies, and
currently causes circusd to spin on the handler in a busy loop.

I didn't notice this before submitting the last pull request, sorry.  It's an important follow-up fix.
