### PR TITLE
Refs #408 - Add statd configuration 

### DIFF
--- a/circus/arbiter.py
+++ b/circus/arbiter.py
@@ -29,8 +29,8 @@ class Arbiter(object):
     - **watchers** -- a list of Watcher objects
     - **endpoint** -- the controller ZMQ endpoint
     - **pubsub_endpoint** -- the pubsub endpoint
-    - **stats_endpoint** -- the stats endpoint. If not provided,
-      the *circusd-stats* process will not be launched.
+    - **statsd** -- If True, a circusd-stats process is run (default: False)
+    - **stats_endpoint** -- the stats endpoint.
     - **multicast_endpoint** -- the multicast endpoint for circusd cluster
       auto-discovery (default: udp://237.219.251.97:12027)
       Multicast addr should be between 224.0.0.0 to 239.255.255.255 and the
@@ -59,7 +59,7 @@ class Arbiter(object):
     - **proc_name** -- the arbiter process name
     """
     def __init__(self, watchers, endpoint, pubsub_endpoint, check_delay=.5,
-                 prereload_fn=None, context=None, loop=None,
+                 prereload_fn=None, context=None, loop=None, statsd=False,
                  stats_endpoint=None, multicast_endpoint=None, plugins=None,
                  sockets=None, warmup_delay=0, httpd=False,
                  httpd_host='localhost', httpd_port=8080, debug=False,
@@ -88,9 +88,10 @@ class Arbiter(object):
             stdout_stream = stderr_stream = None
 
         # initializing circusd-stats as a watcher when configured
+        self.statsd = statsd
         self.stats_endpoint = stats_endpoint
 
-        if self.stats_endpoint is not None:
+        if self.statsd:
             cmd = "%s -c 'from circus import stats; stats.main()'" % \
                 sys.executable
             cmd += ' --endpoint %s' % self.endpoint
@@ -177,6 +178,7 @@ class Arbiter(object):
         arbiter = cls(watchers, cfg['endpoint'], cfg['pubsub_endpoint'],
                       check_delay=cfg.get('check_delay', 1.),
                       prereload_fn=cfg.get('prereload_fn'),
+                      statsd=cfg.get('statsd', False),
                       stats_endpoint=cfg.get('stats_endpoint'),
                       multicast_endpoint=cfg.get('multicast_endpoint'),
                       plugins=cfg.get('plugins'), sockets=sockets,

--- a/circus/config.py
+++ b/circus/config.py
@@ -1,10 +1,11 @@
+import glob
 import os
 import sys
-import glob
+import warnings
 
 from circus import logger
 from circus.util import (DEFAULT_ENDPOINT_DEALER, DEFAULT_ENDPOINT_SUB,
-                         DEFAULT_ENDPOINT_MULTICAST,
+                         DEFAULT_ENDPOINT_MULTICAST, DEFAULT_ENDPOINT_STATS,
                          StrictConfigParser, parse_env_str)
 try:
     import gevent       # NOQA
@@ -113,10 +114,19 @@ def get_config(config_file):
     config['endpoint'] = dget('circus', 'endpoint', DEFAULT_ENDPOINT_DEALER)
     config['pubsub_endpoint'] = dget('circus', 'pubsub_endpoint',
                                      DEFAULT_ENDPOINT_SUB)
-    config['stats_endpoint'] = dget('circus', 'stats_endpoint', None, str)
-
     config['multicast_endpoint'] = dget('circus', 'multicast_endpoint',
                                         DEFAULT_ENDPOINT_MULTICAST)
+    config['stats_endpoint'] = dget('circus', 'stats_endpoint', None)
+    config['statsd'] = dget('circus', 'statsd', False, bool)
+
+    if config['stats_endpoint'] is None:
+        config['stats_endpoint'] = DEFAULT_ENDPOINT_STATS
+    elif not config['statsd']:
+        warnings.warn("You defined a stats_endpoint without "
+                      "setting up statsd to True.",
+                      DeprecationWarning)
+        config['statsd'] = True
+
     config['warmup_delay'] = dget('circus', 'warmup_delay', 0, int)
     config['httpd'] = dget('circus', 'httpd', False, bool)
     config['httpd_host'] = dget('circus', 'httpd_host', 'localhost', str)

--- a/circus/tests/support.py
+++ b/circus/tests/support.py
@@ -10,8 +10,8 @@ import pstats
 import unittest2 as unittest
 
 from circus import get_arbiter
-from circus.util import (DEFAULT_ENDPOINT_STATS, DEFAULT_ENDPOINT_DEALER,
-                         DEFAULT_ENDPOINT_SUB)
+from circus.util import (DEFAULT_ENDPOINT_DEALER, DEFAULT_ENDPOINT_SUB,
+                         DEFAULT_ENDPOINT_STATS)
 from circus.client import CircusClient, make_message
 from circus._zmq import ioloop
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -54,9 +54,10 @@ circus - single section
     **pubsub_endpoint**
         The ZMQ PUB/SUB socket receiving publications of events.
         (default: *tcp://127.0.0.1:5556*)
+    **statsd**
+        If set to True, Circus runs the circusd-stats daemon. (default: False)
     **stats_endpoint**
         The ZMQ PUB/SUB socket receiving publications of stats.
-        If not configured, this feature is deactivated.
         (default: *tcp://127.0.0.1:5557*)
     **check_delay**
         The polling interval in seconds for the ZMQ socket. (default: 5)


### PR DESCRIPTION
With that we can activate the circusd-stats worker without redifining the stats_endpoint

Refs #408 
