### PR TITLE
Wildcards mechanism added to 'env' section

### DIFF
--- a/circus/config.py
+++ b/circus/config.py
@@ -258,6 +258,11 @@ def get_config(config_file):
                     environs[watcher_name].update(
                         [(k.upper(), v) for k, v in cfg.items(section)])
 
+        if section == 'env':
+            for watcher in watchers:
+                environs[watcher['name']].update(
+                    [(k.upper(), v) for k, v in cfg.items(section)])
+
     for watcher in watchers:
         if watcher['name'] in environs:
             if not 'env' in watcher:

--- a/circus/tests/env_section.ini
+++ b/circus/tests/env_section.ini
@@ -21,8 +21,11 @@ LIE = cake
 [env:watcher1,watcher2]
 PATH = $PATH:/bin
 
-[env:wat*]
+[env]
 TEST1 = test1
 
-[env:*]
+[env:wat*]
 TEST2 = test2
+
+[env:*]
+TEST3 = test3

--- a/circus/tests/test_config.py
+++ b/circus/tests/test_config.py
@@ -108,6 +108,9 @@ class TestConfig(unittest.TestCase):
         self.assertEquals('test2', watcher1.env['TEST2'])
         self.assertEquals('test2', watcher2.env['TEST2'])
 
+        self.assertEquals('test3', watcher1.env['TEST3'])
+        self.assertEquals('test3', watcher2.env['TEST3'])
+
     def test_issue395(self):
         conf = get_config(_CONF['issue395'])
         watcher = conf['watchers'][0]

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -299,12 +299,27 @@ plugin:NAME - as many sections as you want
 Circus comes with a few pre-shipped :ref:`plugins <plugins>` but you can also extend them easily by :ref:`developing your own <develop_plugins>`.
 
 
-env:WATCHERS - as many sections as you want
+env or env[:WATCHERS] - as many sections as you want
 ===========================================
 	**anything**
 		The name of an environment variable to assign value to.
 		bash style environment substitutions are supported.
 		for example, append /bin to `PATH` 'PATH = $PATH:/bin'
+
+Section responsible for delivering environment variable to run processes. 
+
+Example::
+
+   	[watcher:worker1]
+	cmd = ping 127.0.0.1
+
+	[watcher:worker2]
+	cmd = ping 127.0.0.1
+
+	[env]
+	CAKE = lie
+
+The variable `CAKE` will propagated to all watchers defined in config file.
 
 WATCHERS can be a comma separated list of watcher sections to apply this environment to.
 if multiple env sections match a watcher, they will be combine in the order they appear in the configuration file.


### PR DESCRIPTION
I was missing this feature a bit. Created simple mechanism to handle wildcards for `env` section 

``` ini
[watcher:worker1]
cmd = ping 127.0.0.1

[watcher:worker2]
cmd = ping 127.0.0.1

[env:worker*]
PATH = /bin
```

Both `worker1` and `worker2` will be run with PATH = /bin
