### PR TITLE
Fix for #422 Hidden exception when circus-web isn't installed

### DIFF
--- a/circus/__init__.py
+++ b/circus/__init__.py
@@ -9,6 +9,7 @@ __version__ = ".".join(map(str, version_info))
 
 
 logger = logging.getLogger('circus')
+logging.basicConfig()
 
 
 def get_arbiter(watchers, controller=None,


### PR DESCRIPTION
Happens because logger is not configured in circusd.py until after the the arbiter instance is created to parse the config.
