### PR TITLE
Ensure env sections are applied to all watchers.

### DIFF
--- a/circus/config.py
+++ b/circus/config.py
@@ -243,6 +243,8 @@ def get_config(config_file):
 
             watchers.append(watcher)
 
+    # Second pass to make sure env sections apply to all watchers.
+    for section in cfg.sections():
         if section.startswith('env:'):
             section_elements = section.split("env:", 1)[1]
             watcher_patterns = [s.strip() for s in section_elements.split(',')]


### PR DESCRIPTION
c3cddba3 breaks existing configuration files where env:name sections come before the corresponding watcher sections.  So, apply env sections after parsing all other sections.
