### PR TITLE
Move python version getter to utils

### DIFF
--- a/circus/py3compat.py
+++ b/circus/py3compat.py
@@ -1,6 +1,9 @@
 import sys
 
-PY3 = sys.version_info[0] == 3
+from circus.util import get_python_version
+
+
+PY3 = get_python_version()[0] == 3
 
 if PY3:
     string_types = str

--- a/circus/tests/test_util.py
+++ b/circus/tests/test_util.py
@@ -8,7 +8,8 @@ from mock import Mock, patch
 
 
 from circus.util import (get_info, bytes2human, to_bool, parse_env_str,
-                         env_to_str, to_uid, to_gid, replace_gnu_args)
+                         env_to_str, to_uid, to_gid, replace_gnu_args,
+                         get_python_version)
 
 
 class TestUtil(unittest.TestCase):
@@ -142,3 +143,14 @@ class TestUtil(unittest.TestCase):
         self.assertEquals('thats an int 2',
                           repl('thats an int ((me))', prefix=None,
                           me=2))
+
+    def test_get_python_version(self):
+        py_version = get_python_version()
+
+        self.assertEquals(3, len(py_version))
+
+        map(lambda x: self.assertEquals(int, type(x)), py_version)
+
+        self.assertGreaterEqual(py_version[0], 2)
+        self.assertGreaterEqual(py_version[1], 0)
+        self.assertGreaterEqual(py_version[2], 0)

--- a/circus/tests/test_watcher.py
+++ b/circus/tests/test_watcher.py
@@ -11,6 +11,7 @@ from circus.stream import QueueStream
 from circus.watcher import Watcher
 from circus.process import UNEXISTING
 from circus import logger
+from circus.util import get_python_version
 
 import warnings
 
@@ -165,10 +166,12 @@ class TestWatcherInitialization(TestCircus):
         watcher.start()
         try:
             time.sleep(.1)
-            minor = sys.version_info[1]
-            wanted = os.path.join(venv, 'lib', 'python2.%d' % minor,
+            py_version = get_python_version()
+            major = py_version[0]
+            minor = py_version[1]
+            wanted = os.path.join(venv, 'lib', 'python%d.%d' % (major, minor),
                                   'site-packages',
-                                  'pip-7.7-py2.%d.egg' % minor)
+                                  'pip-7.7-py%d.%d.egg' % (major, minor))
             ppath = watcher.watcher.env['PYTHONPATH']
         finally:
             watcher.stop()
@@ -180,8 +183,10 @@ class TestWatcherInitialization(TestCircus):
         watcher.start()
         try:
             time.sleep(.1)
-            minor = sys.version_info[1]
-            wanted = os.path.join(venv, 'lib', 'python2.%d' % minor,
+            py_version = get_python_version()
+            major = py_version[0]
+            minor = py_version[1]
+            wanted = os.path.join(venv, 'lib', 'python%d.%d' % (major, minor),
                                   'site-packages')
             ppath = watcher.watcher.env['PYTHONPATH']
         finally:

--- a/circus/util.py
+++ b/circus/util.py
@@ -16,8 +16,6 @@ from ConfigParser import (ConfigParser, MissingSectionHeaderError,
 
 from psutil import AccessDenied, NoSuchProcess, Process
 
-from circus.py3compat import string_types
-
 
 # default endpoints
 DEFAULT_ENDPOINT_DEALER = "tcp://127.0.0.1:5555"
@@ -238,6 +236,8 @@ def to_uid(name):
         except KeyError:
             raise ValueError("%r isn't a valid user id" % name)
 
+    from circus.py3compat import string_types  # circular import fix
+
     if not isinstance(name, string_types):
         raise TypeError(name)
 
@@ -260,6 +260,8 @@ def to_gid(name):
         # see http://bugs.python.org/issue17531
         except (KeyError, OverflowError):
             raise ValueError("No such group: %r" % name)
+
+    from circus.py3compat import string_types  # circular import fix
 
     if not isinstance(name, string_types):
         raise TypeError(name)
@@ -300,6 +302,11 @@ def close_on_exec(fd):
     flags = fcntl.fcntl(fd, fcntl.F_GETFD)
     flags |= fcntl.FD_CLOEXEC
     fcntl.fcntl(fd, fcntl.F_SETFD, flags)
+
+
+def get_python_version():
+    """Get a 3 element tuple with the python version"""
+    return sys.version_info[:3]
 
 
 INDENTATION_LEVEL = 0


### PR DESCRIPTION
There was a circular dependency between `py3compat.py` and `utils.py`

I solved setting the imports from `py3compat` in the functions

https://github.com/slok/circus/blob/py-version-util/circus/util.py#L239
https://github.com/slok/circus/blob/py-version-util/circus/util.py#L264

I don't think that is the best approach :/
