### PR TITLE
Better nginx config

### DIFF
--- a/docs/source/circushttpd.rst
+++ b/docs/source/circushttpd.rst
@@ -238,6 +238,21 @@ prompt will pop when you access the console.
 You can use Apache's htpasswd script to edit it, or the Python script they
 provide at: http://trac.edgewall.org/browser/trunk/contrib/htpasswd.py
 
+However, there's no native support for the combined use of HTTP Authentication and
+WebSockets (the server will throw HTTP 401 error codes). A workaround is to
+disable such authentication for the socket.io server.
+
+Example (needs to be added before the previous rule)::
+
+    location /socket.io {
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-Host: $http_host;
+        proxy_set_header X-Forwarded-Proto: $scheme;
+        proxy_redirect off;
+        proxy_pass http://127.0.0.1:8080;
+    }
+
 Of course that's just one way to protect your web console, you could use
 many other techniques.
 


### PR DESCRIPTION
Update the documentation to improve the sample nginx config chunks : 
- Tweaks the headers to allow Bottle to properly set the host and scheme for the socket.io WebSocket server. This allows to use SSL (HTTPS+WSS) by simply proxying the web console through a HTTPS connection. The previous config still used plain WebSocket (`ws://*` and `http://*`) when the rest of the console used SSL (`https://*`)
- Add a workaround to allow WebSockets to work when the console is protected by HTTP authentication. socket.io doesn't support WebSockets when the ressource is protected by HTTP auth (at least not natively). The server throws HTTP 401 error codes, breaking the live stat functionnality. A workaround is to disable HTTP auth for WebSockets.
