### PR TITLE
Empty Includes

### DIFF
--- a/circus/config.py
+++ b/circus/config.py
@@ -107,9 +107,9 @@ def read_config(config_path):
 
         paths = glob.glob(filename)
         if paths == []:
-            raise IOError('%r does not lead to any config. Make sure '
-                          'include paths are relative to the main config '
-                          'file' % filename)
+            logger.warn('%r does not lead to any config. Make sure '
+                        'include paths are relative to the main config '
+                        'file' % filename)
         includes += paths
 
     for include_file in cfg.dget('circus', 'include', '').split():

--- a/circus/tests/empty_include.ini
+++ b/circus/tests/empty_include.ini
@@ -1,0 +1,3 @@
+[circus]
+include = garbage*.ini
+include_dir = empty

--- a/circus/tests/test_config.py
+++ b/circus/tests/test_config.py
@@ -1,6 +1,9 @@
 import unittest
 import os
 
+from mock import patch
+
+from circus import logger
 from circus.config import get_config
 from circus.watcher import Watcher
 from circus.process import Process
@@ -19,6 +22,7 @@ _CONF = {
     'env_var': os.path.join(HERE, 'env_var.ini'),
     'env_section': os.path.join(HERE, 'env_section.ini'),
     'multiple_wildcard': os.path.join(HERE, 'multiple_wildcard.ini'),
+    'empty_include': os.path.join(HERE, 'empty_include.ini'),
     'circus': os.path.join(HERE, 'circus.ini'),
     'nope': os.path.join(HERE, 'nope.ini'),
     'issue442': os.path.join(HERE, 'issue442.ini')
@@ -70,6 +74,15 @@ class TestConfig(unittest.TestCase):
         conf = get_config(_CONF['multiple_wildcard'])
         watchers = conf['watchers']
         self.assertEquals(len(watchers), 3)
+
+    @patch.object(logger, 'warn')
+    def test_empty_include(self, mock_logger_warn):
+        """https://github.com/mozilla-services/circus/pull/473"""
+        try:
+            conf = get_config(_CONF['empty_include'])
+        except:
+            self.fail('Non-existent includes should not raise')
+        self.assertTrue(mock_logger_warn.called)
 
     def test_watcher_graceful_timeout(self):
         conf = get_config(_CONF['issue210'])


### PR DESCRIPTION
Currently, circus will fail to launch when one of the include directives
(include or include_dir) yields an empty set. This seems a little overly
protective and a simple warning emitted into the log should suffice.

Update _scan in read_config to write the previous exception message as a
log message at the warn level.

A little more background:
I'm deploying circus via Salt Stack and have a recipe I share amongst the various roles in our application's infrastructure. One of the config lines I use `include_dir = /etc/circus` and that's worked so far as all of our roles that include circus deploy INI files there and circus hums along. One of our roles needs circus running and is going to be used to dynamically deploy watchers to. I'd like to continue using that base circus module and have circus just ignore the fact that /etc/circus is going to be empty. Also, as stated in the commit message, I simply felt that dying was a little too extreme for a relatively minor issue.
