### PR TITLE
Update circus.upstart

### DIFF
--- a/debian/circus.upstart
+++ b/debian/circus.upstart
@@ -1,10 +1,9 @@
 description "circusd"
 
-start on (net-device-up
-          and local-filesystems
-          and runlevel [2345])
-stop on runlevel [!2345]
+start on filesystem and net-device-up IFACE=lo
+stop on shutdown
 
 respawn
-
-exec /usr/bin/circusd /etc/circus/circusd.ini
+exec /usr/bin/circusd --log-output /var/log/circus.log \
+                      --pidfile /var/run/circusd.pid \
+                      /etc/circus/circusd.ini


### PR DESCRIPTION
There was a mismatch between this file and the one showed in the documentation in the `Deployment` section.
The one in the documentation is more correct and so I updated this one.

To avoid things like this in the future Sphinx's `include` directive could be used, to always include up-to-date files from the repo.
