### PR TITLE
Fixed TestWatcherInitialization.test_copy_path test

### DIFF
--- a/circus/tests/test_watcher.py
+++ b/circus/tests/test_watcher.py
@@ -4,6 +4,7 @@ import os
 import threading
 import time
 import warnings
+import Queue
 
 import mock
 from zmq.eventloop import ioloop
@@ -54,7 +55,7 @@ class TestWatcher(TestCircus):
         super(TestCircus, self).tearDown()
         current = self.numprocesses('numprocesses')
         if current > 1:
-            self.numprocesses('decr', name='test', nb=current-1)
+            self.numprocesses('decr', name='test', nb=current - 1)
 
     def status(self, cmd, **props):
         resp = self.call(cmd, **props)
@@ -224,13 +225,17 @@ class TestWatcherInitialization(TestCircus):
             os.environ = old_environ
 
     def test_copy_path(self):
+        messages = []
         watcher = SomeWatcher()
         watcher.start()
-        # wait for watcher data at most 5s
-        data = watcher.stream.get(timeout=5)
+        while True:
+            try:
+                m = watcher.stream.get(timeout=1)
+            except Queue.Empty:
+                break
+            messages.append(m)
         watcher.stop()
-        data = [v for k, v in data.items()][1]
-        data = ''.join(data)
+        data = ''.join(m['data'] for m in messages)
         self.assertTrue('XYZ' in data, data)
 
     def test_venv(self):


### PR DESCRIPTION
More than one Queue.get call is needed to get full
output from a watcher in an environment with rich sys.path.
