### PR TITLE
Fixed Arbiter.reload_from_config (httpd and statsd stopped)

### DIFF
--- a/circus/arbiter.py
+++ b/circus/arbiter.py
@@ -246,8 +246,11 @@ class Arbiter(object):
         if self.get_arbiter_config(new_cfg) != self._cfg:
             raise ReloadArbiterException
 
+        ignore_sn = set(['circushttpd'])
+        ignore_wn = set(['circushttpd', 'circusd-stats'])
+
         # Gather socket names.
-        current_sn = set([i.name for i in self.sockets.values()])
+        current_sn = set([i.name for i in self.sockets.values()]) - ignore_sn
         new_sn = set([i['name'] for i in new_cfg.get('sockets', [])])
         added_sn = new_sn - current_sn
         deleted_sn = current_sn - new_sn
@@ -301,7 +304,7 @@ class Arbiter(object):
                 watcher.initialize(self.evpub_socket, self.sockets, self)
 
         # Gather watcher names.
-        current_wn = set([i.name for i in self.iter_watchers()])
+        current_wn = set([i.name for i in self.iter_watchers()]) - ignore_wn
         new_wn = set([i['name'] for i in new_cfg.get('watchers', [])])
         new_wn = new_wn | set([i['name'] for i in new_cfg.get('plugins', [])])
         added_wn = (new_wn - current_wn) | wn_with_changed_socket

--- a/circus/tests/config/reload_statsd.ini
+++ b/circus/tests/config/reload_statsd.ini
@@ -1,0 +1,19 @@
+[circus]
+check_delay = 5
+endpoint = tcp://127.0.0.1:7555
+pubsub_endpoint = tcp://127.0.0.1:7556
+stats_endpoint = tcp://127.0.0.1:5557
+
+[watcher:test1]
+cmd = sleep 120
+
+[watcher:test2]
+cmd = sleep 120
+
+[socket:mysocket]
+host = localhost
+port = 8889
+
+[plugin:myplugin]
+use = circus.plugins.resource_watcher.ResourceWatcher
+watcher = test1

--- a/circus/tests/test_reloadconfig.py
+++ b/circus/tests/test_reloadconfig.py
@@ -24,6 +24,7 @@ _CONF = {
                                          'reload_changesockets.ini'),
     'reload_changearbiter': os.path.join(CONFIG_DIR,
                                          'reload_changearbiter.ini'),
+    'reload_statsd': os.path.join(CONFIG_DIR, 'reload_statsd.ini'),
 }
 
 
@@ -48,8 +49,8 @@ class TestConfig(unittest.TestCase):
             watcher.stop()
         a.sockets.close_all()
 
-    def _load_base_arbiter(self):
-        a = Arbiter.load_from_config(_CONF['reload_base'])
+    def _load_base_arbiter(self, name='reload_base'):
+        a = Arbiter.load_from_config(_CONF[name])
         a.evpub_socket = FakeSocket()
         # initialize watchers
         for watcher in a.iter_watchers():
@@ -144,3 +145,11 @@ class TestConfig(unittest.TestCase):
         finally:
             del os.environ['SHRUBBERY']
             self._tear_down_arbiter(a)
+
+    def test_reload_ignorearbiterwatchers(self):
+        a = self._load_base_arbiter('reload_statsd')
+        statsd = a.get_watcher('circusd-stats')
+
+        a.reload_from_config(_CONF['reload_statsd'])
+
+        self.assertEqual(statsd, a.get_watcher('circusd-stats'))


### PR DESCRIPTION
circushttpd and circusd-stats watchers were stopped for no reason.
reload_from_config does not allow [arbiter] changes, so sockets
and watchers created on [arbiter]'s behalf should be ignored when
looking for changes.
