### PR TITLE
reloadconfig fails if circus is managing circushttpd daemon

### DIFF
--- a/circus/__init__.py
+++ b/circus/__init__.py
@@ -19,7 +19,7 @@ class ArbiterHandler(object):
                  statsd_close_outputs=False,
                  multicast_endpoint=None,
                  env=None, name=None, context=None,
-                 background=False, stream_backend="thread",
+                 background=False, stream_backend="thread", httpd=False,
                  plugins=None, debug=False, proc_name="circusd"):
         """Creates a Arbiter and a single watcher in it.
 
@@ -128,7 +128,7 @@ class ArbiterHandler(object):
             _watchers.append(Watcher.load_from_config(watcher))
 
         return Arbiter(_watchers, controller, pubsub_endpoint,
-                       statsd=statsd,
+                       httpd=httpd, statsd=statsd,
                        stats_endpoint=stats_endpoint,
                        statsd_close_outputs=statsd_close_outputs,
                        multicast_endpoint=multicast_endpoint,

--- a/circus/arbiter.py
+++ b/circus/arbiter.py
@@ -144,7 +144,6 @@ class Arbiter(object):
 
         # adding the httpd
         if httpd:
-
             # adding the socket
             httpd_socket = CircusSocket(name='circushttpd', host=httpd_host,
                                         port=httpd_port)

--- a/circus/tests/support.py
+++ b/circus/tests/support.py
@@ -186,8 +186,40 @@ def has_gevent():
         return False
 
 
+def has_circusweb():
+    try:
+        import circusweb       # NOQA
+        return True
+    except ImportError:
+        return False
+
+
 class TimeoutException(Exception):
     pass
+
+
+def poll_for_callable(func, *args, **kwargs):
+    """Replay to update the status during timeout seconds."""
+    timeout = 5
+
+    if 'timeout' in kwargs:
+        timeout = kwargs.pop('timeout')
+
+    start = time()
+    while time() - start < timeout:
+        try:
+            func_args = []
+            for arg in args:
+                if callable(arg):
+                    func_args.append(arg())
+                else:
+                    func_args.append(arg)
+            func(*func_args)
+        except AssertionError as e:
+            sleep(0.1)
+        else:
+            return True
+    raise e
 
 
 def poll_for(filename, needles, timeout=5):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,docs,py26,py27,py26-no-gevent,py27-no-gevent
+envlist = flake8,docs,py26,py27,py26-no-gevent,py27-no-gevent,circus-web
 
 
 [testenv:py26-no-gevent]
@@ -27,3 +27,8 @@ commands = /usr/bin/make docs
 
 [testenv:flake8]
 commands = flake8 circus
+
+[testenv:circus-web]
+deps =
+    -r{toxinidir}/test-requirements.txt
+    circus-web


### PR DESCRIPTION
When we have httpd = True on [circus] section, reloadconfig fails with the error below. 

Environ:
- circus==0.9.2 (installed via pip  / pypi)
- python 2.7
- Reproduced on ubuntu 12.04 and RHEL5

Circus debug log: 

```
2013-09-24 16:42:42 [5369] [DEBUG] got message {"command": "reloadconfig", "properties": {}}
2013-09-24 16:42:42 [5369] [DEBUG] Reading config files: ['/etc/circus/cams.d/jamaica-1.ini']
2013-09-24 16:42:42 [5369] [DEBUG] error: command '{"command": "reloadconfig", "properties": {}}': Watchers set(['circushttpd']) uses a socket which is deleted

Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/circus/controller.py", line 125, in dispatch
    resp = cmd.execute(self.arbiter, properties)
  File "/usr/local/lib/python2.7/dist-packages/circus/commands/reloadconfig.py", line 41, in execute
    arbiter.reload_from_config()
  File "/usr/local/lib/python2.7/dist-packages/circus/arbiter.py", line 314, in reload_from_config
    wn_with_deleted_socket)
ValueError: Watchers set(['circushttpd']) uses a socket which is deleted
```
- circus.ini:

```
[circus]
statsd = True
httpd = True
httpd_host = 0.0.0.0
httpd_port = 8080
include = /etc/circus/cams.d/*.ini
logoutput = /var/log/circusd-output.log
loglevel = DEBUG

```
