### PR TITLE
environment variable for socket port

### DIFF
--- a/circus/tests/config/env_everywhere.ini
+++ b/circus/tests/config/env_everywhere.ini
@@ -1,0 +1,13 @@
+[circus]
+endpoint = tcp://127.0.0.1:$(circus.env.ENDPOINT_PORT)
+
+[socket:bad]
+path = /var/run/$(circus.env.BAD_PATH)
+
+[plugin:breaking]
+use = bad.has.been.$(circus.env.WHAT)
+
+[env]
+ENDPOINT_PORT = 1234
+BAD_PATH = broken.sock
+WHAT = broken

--- a/circus/tests/test_config.py
+++ b/circus/tests/test_config.py
@@ -29,7 +29,8 @@ _CONF = {
     'unexistant': os.path.join(CONFIG_DIR, 'unexistant.ini'),
     'issue442': os.path.join(CONFIG_DIR, 'issue442.ini'),
     'expand_vars': os.path.join(CONFIG_DIR, 'expand_vars.ini'),
-    'issue546': os.path.join(CONFIG_DIR, 'issue546.ini')
+    'issue546': os.path.join(CONFIG_DIR, 'issue546.ini'),
+    'env_everywhere': os.path.join(CONFIG_DIR, 'env_everywhere.ini')
 }
 
 
@@ -186,3 +187,10 @@ class TestConfig(unittest.TestCase):
         replaced = replace_gnu_args(conf['watchers'][0]['cmd'],
                                     sockets={'some-socket': 3})
         self.assertEqual(replaced, '../bin/chaussette --fd 3')
+
+    def test_env_everywhere(self):
+        conf = get_config(_CONF['env_everywhere'])
+
+        self.assertEqual(conf['endpoint'], 'tcp://127.0.0.1:1234')
+        self.assertEqual(conf['sockets'][0]['path'], '/var/run/broken.sock')
+        self.assertEqual(conf['plugins'][0]['use'], 'bad.has.been.broken')

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -410,6 +410,13 @@ Example::
     bar = $(circus.env.yeah)
     sup = $(circus.env.oh)
 
+    [socket:socket1]
+    port = $(circus.env.port)
+
+    [plugin:plugin1]
+    use = some.path
+    parameter1 = $(circus.env.plugin_param)
+
     [env]
     yeah = boo
 
@@ -420,6 +427,9 @@ If a variable is defined in several places, the most specialized
 value has precedence: a variable defined in *env:XXX* will override
 a variable defined in *env*, which will override a variable
 defined in *os.environ*.
+
+environment substitutions can be used in any section of the configuration
+in any section variable.
 
 
 .. _formatting_cmd:


### PR DESCRIPTION
consider this simple configuration

```
[watcher:web]
cmd = chaussette --fd $(circus.sockets.web) my.app
use_sockets = True

[socket:web]
host = 0.0.0.0
port = 5000
```

assume you are running circus in a 'heroku' like environment where the port can/will change on every startup.

```
[watcher:web]
cmd = chaussette --fd $(circus.sockets.web) my.app
use_sockets = True

[socket:web]
host = 0.0.0.0
port = $(CIRCUS.ENV.PORT)
```

unfortunately it seems variables are only expanded in watcher sections.

I think it would be a useful addition to expand variables from the `[env]` section and `os.environ` in ALL sections. watcher section behavior would not change, but all variables in socket/plugin sections could use variables from the `[env]` section and `os.environ`

what do you guys think?  I would be able to add this pretty easily, but I wanted to see if anyone agrees before I submit a PR that wouldn't be merged.
