### PR TITLE
environment substitutions and copy_env

### DIFF
--- a/circus/tests/config/issue567.ini
+++ b/circus/tests/config/issue567.ini
@@ -1,0 +1,2 @@
+[watcher:watcher1]
+cmd = $(circus.env.GRAVITY)

--- a/circus/tests/test_config.py
+++ b/circus/tests/test_config.py
@@ -31,7 +31,8 @@ _CONF = {
     'expand_vars': os.path.join(CONFIG_DIR, 'expand_vars.ini'),
     'issue546': os.path.join(CONFIG_DIR, 'issue546.ini'),
     'env_everywhere': os.path.join(CONFIG_DIR, 'env_everywhere.ini'),
-    'copy_env': os.path.join(CONFIG_DIR, 'copy_env.ini')
+    'copy_env': os.path.join(CONFIG_DIR, 'copy_env.ini'),
+    'issue567': os.path.join(CONFIG_DIR, 'issue567.ini')
 }
 
 
@@ -213,3 +214,11 @@ class TestConfig(unittest.TestCase):
             else:
                 self.assertTrue('BAM' in watcher['env'])
             self.assertTrue('TEST1' in watcher['env'])
+
+    def test_issue567(self):
+        os.environ['GRAVITY'] = 'down'
+        conf = get_config(_CONF['issue567'])
+
+        # make sure the global environment makes it into the cfg environment
+        # even without [env] section
+        self.assertEqual(conf['watchers'][0]['cmd'], 'down')


### PR DESCRIPTION
After the bug fix in #564, it is impossible to substitute variables from the environment circus is run in without using `copy_env=True`

How should the following be handled?

```
[watcher:w1]
cmd = $(circus.env.executable)
```

Should watcher sections be able to substitute from the global environment without `copy_env=True`, since all other sections can always do this.
