### PR TITLE
Do not install unittest2 on Python 2.7.

### DIFF
--- a/test-requirements-py26.txt
+++ b/test-requirements-py26.txt
@@ -2,5 +2,6 @@
 
 flake8==1.7.0
 mock==1.0.1
+unittest2==0.5.1
 python-coveralls==2.4.0
 nose-cov==1.6

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,6 +2,5 @@
 
 flake8==1.7.0
 mock==1.0.1
-unittest2==0.5.1
 python-coveralls==2.4.0
 nose-cov==1.6

--- a/tox.ini
+++ b/tox.ini
@@ -3,15 +3,19 @@ envlist = flake8,docs,py26,py27,py26-no-gevent,py27-no-gevent,py33,circus-web
 
 [testenv:py33]
 deps =
-    -r{toxinidir}/test-requirements-py3.txt
+    -r{toxinidir}/test-requirements.txt
 
 commands =
     python setup.py develop
     python -Wdefault -c 'import nose; nose.main()' -sv circus/tests
 
+[testenv:py26]
+deps =
+    -r{toxinidir}/test-requirements-py26.txt
+
 [testenv:py26-no-gevent]
 deps =
-    -r{toxinidir}/test-requirements.txt
+    -r{toxinidir}/test-requirements-py26.txt
 
 [testenv:py27-no-gevent]
 deps =


### PR DESCRIPTION
You don't need unittest2 on 2.7. So the the default test-requirements.txt should be used on 2.7 and 3.3 while only 2.6 installs unittest2.
