### PR TITLE
Add stop_signal feature

### DIFF
--- a/circus/commands/quit.py
+++ b/circus/commands/quit.py
@@ -20,11 +20,11 @@ class Quit(Command):
 
         The response return the status "ok".
 
-        If ``waiting`` is False (default), the call will return immediatly
-        after calling SIGTERM on each process.
+        If ``waiting`` is False (default), the call will return immediately
+        after calling ``stop_signal`` on each process.
 
         If ``waiting`` is True, the call will return only when the stop process
-        is completly ended. Because of the
+        is completely ended. Because of the
         :ref:`graceful_timeout option <graceful_timeout>`, it can take some
         time.
 

--- a/circus/commands/restart.py
+++ b/circus/commands/restart.py
@@ -29,7 +29,7 @@ class Restart(Command):
         to the watcher.
 
         If ``waiting`` is False (default), the call will return immediatly
-        after calling SIGTERM on each process.
+        after calling `stop_signal` on each process.
 
         If ``waiting`` is True, the call will return only when the restart
         process is completly ended. Because of the

--- a/circus/commands/stop.py
+++ b/circus/commands/stop.py
@@ -28,7 +28,7 @@ class Stop(Command):
         will get stopped.
 
         If ``waiting`` is False (default), the call will return immediatly
-        after calling SIGTERM on each process.
+        after calling `stop_signal` on each process.
 
         If ``waiting`` is True, the call will return only when the stop process
         is completly ended. Because of the

--- a/circus/commands/util.py
+++ b/circus/commands/util.py
@@ -21,6 +21,8 @@ def convert_option(key, val):
         return val
     elif key == "send_hup":
         return util.to_bool(val)
+    elif key == "stop_signal":
+        return util.to_signum(val)
     elif key == "shell":
         return util.to_bool(val)
     elif key == "copy_env":

--- a/circus/config.py
+++ b/circus/config.py
@@ -1,12 +1,13 @@
 import glob
 import os
+import signal
 import warnings
 from fnmatch import fnmatch
 
 from circus import logger
 from circus.util import (DEFAULT_ENDPOINT_DEALER, DEFAULT_ENDPOINT_SUB,
                          DEFAULT_ENDPOINT_MULTICAST, DEFAULT_ENDPOINT_STATS,
-                         StrictConfigParser, replace_gnu_args)
+                         StrictConfigParser, replace_gnu_args, to_signum)
 
 
 def watcher_defaults():
@@ -22,6 +23,7 @@ def watcher_defaults():
         'uid': None,
         'gid': None,
         'send_hup': False,
+        'stop_signal': signal.SIGTERM,
         'max_retry': 5,
         'graceful_timeout': 30,
         'rlimits': dict(),
@@ -217,6 +219,8 @@ def get_config(config_file):
                 elif opt == 'send_hup':
                     watcher['send_hup'] = dget(section, 'send_hup', False,
                                                bool)
+                elif opt == 'stop_signal':
+                    watcher['stop_signal'] = to_signum(val)
                 elif opt == 'check_flapping':
                     watcher['check_flapping'] = dget(section, 'check_flapping',
                                                      True, bool)

--- a/circus/tests/config/issue594.ini
+++ b/circus/tests/config/issue594.ini
@@ -1,0 +1,11 @@
+[circus]
+check_delay = 5
+endpoint = tcp://127.0.0.1:5555
+pubsub_endpoint = tcp://127.0.0.1:5556
+stats_endpoint = tcp://127.0.0.1:5557
+statsd = true
+
+[watcher:my_app]
+cmd = boo
+graceful_timeout=30
+stop_signal=INT

--- a/circus/tests/test_config.py
+++ b/circus/tests/test_config.py
@@ -1,4 +1,5 @@
 import os
+import signal
 from mock import patch
 
 from circus import logger
@@ -33,7 +34,8 @@ _CONF = {
     'issue546': os.path.join(CONFIG_DIR, 'issue546.ini'),
     'env_everywhere': os.path.join(CONFIG_DIR, 'env_everywhere.ini'),
     'copy_env': os.path.join(CONFIG_DIR, 'copy_env.ini'),
-    'issue567': os.path.join(CONFIG_DIR, 'issue567.ini')
+    'issue567': os.path.join(CONFIG_DIR, 'issue567.ini'),
+    'issue594': os.path.join(CONFIG_DIR, 'issue594.ini'),
 }
 
 
@@ -231,5 +233,12 @@ class TestConfig(TestCase):
         # make sure the global environment makes it into the cfg environment
         # even without [env] section
         self.assertEqual(conf['watchers'][0]['cmd'], 'down')
+
+    def test_watcher_stop_signal(self):
+        conf = get_config(_CONF['issue594'])
+        self.assertEqual(conf['watchers'][0]['stop_signal'], signal.SIGINT)
+        watcher = Watcher.load_from_config(conf['watchers'][0])
+        watcher.stop()
+
 
 test_suite = EasyTestSuite(__name__)

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -182,8 +182,15 @@ watcher:NAME - as many sections as you want
         /dev/null after the fork. Defaults to False.
 
     **send_hup**
-        if True, a process reload will be done by sending the SIGHUP signal.
+        If True, a process reload will be done by sending the SIGHUP signal.
         Defaults to False.
+
+    **stop_signal**
+        The signal to send when stopping the process. Can be specified as a
+        number or a signal name. Signal names are case-insensitive and can
+        include 'SIG' or not. So valid examples include `quit`, `INT`,
+        `SIGTERM` and `3`.
+        Defaults to SIGTERM.
 
     **max_retry**
         The number of times we attempt to start a process, before
@@ -196,7 +203,7 @@ watcher:NAME - as many sections as you want
         The number of seconds to wait for a process to terminate gracefully
         before killing it.
 
-        When stopping a process, we first send it a SIGTERM signal. A worker
+        When stopping a process, we first send it a :ref:`stop_signal`. A worker
         may catch this signal to perform clean up operations before exiting.
         If the worker is still active after graceful_timeout seconds, we send
         it a SIGKILL signal.  It is not possible to catch SIGKILL signals so


### PR DESCRIPTION
I added the ability to specify _stop_signal_ for a watcher and enhanced the _signal_ command to allow any signal listed in signals.py. I moved the signal name-to-number translation from sendsignal.py to utils.
