### PR TITLE
Add a mozilla-sphinx-theme dependency in the makefile / toxfile.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "docs/source/_themes/mozilla"]
-	path = docs/source/_themes/mozilla
-	url = https://github.com/mozilla/mozilla-sphinx-theme.git

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: docs build test coverage build_rpm clean
 
 ifndef VTENV_OPTS
-VTENV_OPTS = "--no-site-packages"
+VTENV_OPTS = -p python2.7 --no-site-packages
 endif
 
 bin/python:
@@ -13,7 +13,7 @@ test: bin/python
 	bin/tox
 
 docs: 
-	bin/pip install sphinx
+	bin/pip install sphinx mozilla-sphinx-theme
 	SPHINXBUILD=../bin/sphinx-build $(MAKE) -C docs html $^ 
 
 coverage: bin/coverage

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,6 +12,7 @@
 # serve to show the default.
 
 import sys, os
+import mozilla_sphinx_theme
 
 class Mock(object):
     def __init__(self, *args, **kwargs):
@@ -124,13 +125,8 @@ exclude_patterns = []
 
 html_short_title = "Circus"
 
-THEMES = os.path.abspath('_themes')
-sys.path.append(THEMES)
-html_theme_path = ['_themes']
-
-MOZ = os.path.join(THEMES, 'mozilla')
-if os.path.exists(MOZ) and len(os.listdir(MOZ)) > 0:
-    html_theme = 'mozilla'
+html_theme_path = [os.path.dirname(mozilla_sphinx_theme.__file__)]
+html_theme = 'mozilla'
 
 #html_logo = "images/circus32.png"
 

--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ commands =
 
 [testenv:docs]
 whitelist_externals = make
-deps = sphinx
+deps = sphinx mozilla-sphinx-theme
 commands = make -C docs html
 
 [testenv:flake8]


### PR DESCRIPTION
Add a dependency to the mozilla sphinx theme and force virtualenv to use py2.7 with the Makefile.
