### PR TITLE
fix 'dict_items' object has no attribute 'sort'

### DIFF
--- a/docs/circus_ext.py
+++ b/docs/circus_ext.py
@@ -30,7 +30,7 @@ def generate_commands(app):
 
     commands = get_commands()
     items = commands.items()
-    items.sort()
+    items = sorted(items)
 
     with open(tocname, "w") as toc:
         toc.write(_HEADER)


### PR DESCRIPTION
Encountered while trying to 'make html' in docs/

```
$make html
sphinx-build -b html -d build/doctrees   source build/html
Making output directory...
Running Sphinx v1.2b3
loading pickled environment... failed: [Errno 2] No such file or directory: '/Users/brent/code/github/fprimex/circus/docs/build/doctrees/environment.pickle'

Exception occurred:
  File "/Users/brent/code/github/fprimex/circus/docs/source/../circus_ext.py", line 33, in generate_commands
    items.sort()
AttributeError: 'dict_items' object has no attribute 'sort'
The full traceback has been saved in /var/folders/8m/wqg7smz93cq78ckkh3n34yl00000gn/T/sphinx-err-4nq7q1.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
Either send bugs to the mailing list at <http://groups.google.com/group/sphinx-users/>,
or report them in the tracker at <http://bitbucket.org/birkenfeld/sphinx/issues/>. Thanks!
make: *** [html] Error 1
```
