### PR TITLE
SO_REUSEPORT optval should be tested for non-zero.

### DIFF
--- a/circus/tests/test_sockets.py
+++ b/circus/tests/test_sockets.py
@@ -136,7 +136,7 @@ class TestSockets(TestCase):
         sockopt = sock.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT)
 
         self.assertEqual(sock.so_reuseport, True)
-        self.assertEqual(sockopt, socket.SO_REUSEPORT)
+        self.assertNotEqual(sockopt, 0)
 
     def test_reuseport_unsupported(self):
         config = {'name': '', 'host': 'localhost', 'port': 0,


### PR DESCRIPTION
This should be a portable solution. On Linux getsockopt
returns 1 even if it is set to non-zero value other than 1.
