### PR TITLE
allow set command to modify watcher args

### DIFF
--- a/circus/commands/util.py
+++ b/circus/commands/util.py
@@ -33,6 +33,8 @@ def convert_option(key, val):
         return util.parse_env_dict(val)
     elif key == "cmd":
         return val
+    elif key == "args":
+        return val
     elif key == "retry_in":
         return float(val)
     elif key == "max_retry":
@@ -79,7 +81,7 @@ def convert_option(key, val):
 def validate_option(key, val):
     valid_keys = ('numprocesses', 'warmup_delay', 'working_dir', 'uid',
                   'gid', 'send_hup', 'stop_signal', 'stop_children',
-                  'shell', 'env', 'cmd', 'copy_env', 'retry_in',
+                  'shell', 'env', 'cmd', 'args', 'copy_env', 'retry_in',
                   'max_retry', 'graceful_timeout', 'stdout_stream',
                   'stderr_stream', 'max_age', 'max_age_variance', 'respawn',
                   'hooks')

--- a/circus/tests/test_command_set.py
+++ b/circus/tests/test_command_set.py
@@ -4,8 +4,9 @@ from circus.commands.set import Set
 
 
 class FakeWatcher(object):
-    actions = []
-    options = {}
+    def __init__(self):
+        self.actions = []
+        self.options = {}
 
     def set_opt(self, key, val):
         self.options[key] = val
@@ -52,5 +53,15 @@ class SetTest(TestCircus):
                          'some')
         self.assertEqual(watcher.options['hooks.after_start'],
                          'hook')
+
+    def test_set_args(self):
+        arbiter = FakeArbiter()
+        cmd = Set()
+
+        props = cmd.message('dummy2', 'args', '--arg1 1 --arg2 2')
+        props = props['properties']
+        cmd.execute(arbiter, props)
+        watcher = arbiter.watchers[0]
+        self.assertEqual(watcher.options['args'], '--arg1 1 --arg2 2')
 
 test_suite = EasyTestSuite(__name__)

--- a/circus/watcher.py
+++ b/circus/watcher.py
@@ -916,6 +916,9 @@ class Watcher(object):
         elif key == "cmd":
             self.cmd = val
             action = 1
+        elif key == "args":
+            self.args = args
+            action = 1
         elif key == "graceful_timeout":
             self.graceful_timeout = float(val)
             action = -1


### PR DESCRIPTION
Watcher command line arguments were not accessible via the set command.  This PR adds that functionality and updates the unit test.
