### PR TITLE
Add extended_stats hook

### DIFF
--- a/circus/__init__.py
+++ b/circus/__init__.py
@@ -72,7 +72,8 @@ class ArbiterHandler(object):
               callable or the callabled itself and a boolean flag indicating if
               an exception occuring in the hook should not be ignored.
               Possible values for the hook name: *before_start*, *after_start*,
-              *before_stop*, *after_stop*, *before_signal*, *after_signal*
+              *before_stop*, *after_stop*, *before_signal*, *after_signal*,
+              *extended_stats*
 
         - **controller** -- the zmq entry point
           (default: 'tcp://127.0.0.1:5555')

--- a/circus/commands/util.py
+++ b/circus/commands/util.py
@@ -5,7 +5,8 @@ import warnings
 
 
 _HOOKS = ('before_start', 'after_start', 'before_stop', 'after_stop',
-          'before_spawn', 'before_signal', 'after_signal')
+          'before_spawn', 'before_signal', 'after_signal',
+          'extended_stats')
 
 
 def convert_option(key, val):

--- a/circus/py3compat.py
+++ b/circus/py3compat.py
@@ -27,13 +27,13 @@ if PY3:
 
     MAXSIZE = sys.maxsize       # NOQA
 else:
-    string_types = basestring
+    string_types = basestring  # NOQA
     integer_types = (int, long)
-    text_type = unicode
+    text_type = unicode  # NOQA
     long = long
 
     def bytestring(s):  # NOQA
-        if isinstance(s, unicode):
+        if isinstance(s, unicode):  # NOQA
             return s.encode('utf-8')
         return s
 

--- a/docs/source/for-devs/writing-hooks.rst
+++ b/docs/source/for-devs/writing-hooks.rst
@@ -29,6 +29,9 @@ events.  Available hooks are:
 
 - **after_signal**: called after a signal is sent to a watcher's process. 
 
+- **extended_stats**: called when stats are requested with extended=True.
+  Used for adding process-specific stats to the regular stats output.
+
 Example
 =======
 
@@ -99,7 +102,7 @@ Where **watcher** is the **Watcher** class instance, **arbiter** the
 **Arbiter** one, **hook_name** the hook name and **kwargs** some additional
 optional parameters (depending on the hook type).
 
-For the moment, only **before_signal** and **after_signal** hooks offer some
+The **before_signal** and **after_signal** hooks offer some
 additional parameters in **kwargs**::
 
     def before_signal_hook(watcher, arbiter, hook_name, pid, signum, **kwargs):
@@ -116,6 +119,15 @@ data and methods can be useful in some hooks.
 
 Note that hooks are called with named arguments. So use the hook signature without
 changing argument names.
+
+The **extended_stats** hook has its own additional parameters in **kwargs**::
+
+    def extended_stats_hook(watcher, arbiter, hook_name, pid, stats, **kwargs):
+        ...
+
+Where **pid** is the PID of the corresponding process and **stats** the
+regular stats to be returned. Add your own stats into **stats**. An example
+is in examples/uwsgi_lossless_reload.py.
 
 As a last example, here is a super hook which can deal with all kind of signals::
 

--- a/docs/source/for-ops/configuration.rst
+++ b/docs/source/for-ops/configuration.rst
@@ -250,7 +250,8 @@ watcher:NAME - as many sections as you want
 
     **hooks.***
         Available hooks: **before_start**, **before_spawn**, **after_start**,
-        **before_stop**, **after_stop**, **before_signal**, **after_signal**
+        **before_stop**, **after_stop**, **before_signal**, **after_signal**,
+        **extended_stats**
 
         Define callback functions that hook into the watcher startup/shutdown process.
 

--- a/examples/uwsgi_lossless_reload.ini
+++ b/examples/uwsgi_lossless_reload.ini
@@ -2,7 +2,8 @@
 cmd = uwsgi --ini uwsgi.ini --socket fd://$(circus.sockets.web) --stats --stats 127.0.0.1:809$(circus.wid)
 stop_signal = QUIT
 use_sockets = True
-hooks.before_signal = uwsgi_clean_stop
+hooks.before_signal = examples.uwsgi_lossless_reload.uwsgi_clean_stop
+hooks.extended_stats = examples.uwsgi_lossless_reload.extended_stats
 
 [socket:web]
 host = 127.0.0.1


### PR DESCRIPTION
I added an extended_stats hook. This is very useful if you want to add process-specific information into the stats. I have an example in examples/uwsgi_lossless_reload.py where I grab additional information from uWSGI's stats engine and merge it into the regular circus stats.

Since the extended stats require extra processing, I made it so you have to request extended=True in the stats command.

I updated docs and unit tests.

Hope you like it.
