### PR TITLE
arbiter:  fix autostart=False watchers during start

### DIFF
--- a/circus/arbiter.py
+++ b/circus/arbiter.py
@@ -691,8 +691,9 @@ class Arbiter(object):
     @gen.coroutine
     def _start_watchers(self):
         for watcher in self.iter_watchers():
-            yield watcher._start()
-            yield tornado_sleep(self.warmup_delay)
+            if watcher.autostart:
+                yield watcher._start()
+                yield tornado_sleep(self.warmup_delay)
 
     @gen.coroutine
     @debuglog

--- a/circus/tests/test_arbiter.py
+++ b/circus/tests/test_arbiter.py
@@ -568,6 +568,18 @@ class TestArbiter(TestCircus):
         finally:
             yield arbiter.stop()
 
+    @tornado.testing.gen_test
+    def test_start_arbiter_with_autostart(self):
+        arbiter = Arbiter([], DEFAULT_ENDPOINT_DEALER, DEFAULT_ENDPOINT_SUB,
+                          loop=tornado.ioloop.IOLoop.instance(),
+                          check_delay=-1)
+        arbiter.add_watcher('foo', 'sleep 5', autostart=False)
+        try:
+            yield arbiter.start()
+            self.assertEqual(arbiter.watchers[0].status(), 'stopped')
+        finally:
+            yield arbiter.stop()
+
 
 @skipIf(not has_circusweb(), 'Tests for circus-web')
 class TestCircusWeb(TestCircus):


### PR DESCRIPTION
In ebec3e50ec3e804caa9df0275d547e07705deae9 arbiter.start() switched
from using arbiter.start_watcher() to using arbiter.start_watchers().
The later does not respect the autostart attribute for each watcher.
This is a regression from behavior in 0.9.2.

Fixed by checking watcher.autostart in arbiter._start_watchers() and
added a unittest to check this in the future.
