### PR TITLE
Reap with exit status

### DIFF
--- a/circus/watcher.py
+++ b/circus/watcher.py
@@ -394,7 +394,9 @@ class Watcher(object):
                                      pid, self.name)
                         self.notify_event(
                             "reap",
-                            {"process_pid": pid, "time": time.time()})
+                            {"process_pid": pid,
+                             "time": time.time(),
+                             "exit_code": None})
                         process.stop()
                         return
                     else:
@@ -402,11 +404,11 @@ class Watcher(object):
 
         # get return code
         if os.WIFSIGNALED(status):
-            os.WTERMSIG(status)
+            exit_code = os.WTERMSIG(status)
         # process exited using exit(2) system call; return the
         # integer exit(2) system call has been called with
         elif os.WIFEXITED(status):
-            os.WEXITSTATUS(status)
+            exit_code = os.WEXITSTATUS(status)
         else:
             # should never happen
             raise RuntimeError("Unknown process exit status")
@@ -416,7 +418,10 @@ class Watcher(object):
             process.stop()
 
         logger.debug('reaping process %s [%s]', pid, self.name)
-        self.notify_event("reap", {"process_pid": pid, "time": time.time()})
+        self.notify_event("reap",
+                          {"process_pid": pid,
+                           "time": time.time(),
+                           "exit_code": exit_code})
 
     @util.debuglog
     def reap_processes(self):


### PR DESCRIPTION
I find it nice to be able to tell what a process's exit code was.  This PR adds that information to the reap event.

Also, fix a bug in watcher.reap_process() where a comparison to None was being incorrectly handled.
