### PR TITLE
Fix : signal command (wrong pid type)

### DIFF
--- a/circus/commands/sendsignal.py
+++ b/circus/commands/sendsignal.py
@@ -152,3 +152,5 @@ class Signal(Command):
             props['signum'] = to_signum(props['signum'])
         except ValueError:
             raise MessageError('signal invalid')
+
+        props['pid'] = int(props['pid'])


### PR DESCRIPTION
`circusctl signal <watchername> <pid> <signal>` would not propagte signal to the process since `<pid>` would be a string and the lookup in processes dict would fail (keys are integers) https://github.com/mozilla-services/circus/blob/master/circus/watcher.py#L652
