### PR TITLE
watcher:  restart after command only if running

### DIFF
--- a/circus/watcher.py
+++ b/circus/watcher.py
@@ -970,7 +970,7 @@ class Watcher(object):
         # trigger needed action
         if num == 0:
             yield self.manage_processes()
-        else:
+        elif not self.is_stopped():
             # graceful restart
             yield self._restart()
 


### PR DESCRIPTION
After processing a command from the client, only restart the watcher if
the watcher was already running.  This allows the client to first set
options on the watcher before starting it.
