### PR TITLE
watcher:  drop log message from error to debug

### DIFF
--- a/circus/watcher.py
+++ b/circus/watcher.py
@@ -389,7 +389,7 @@ class Watcher(object):
                         #
                         # This can happen if poll() or wait() were called on
                         # the underlying process.
-                        logger.error('reaping already dead process %s [%s]',
+                        logger.debug('reaping already dead process %s [%s]',
                                      pid, self.name)
                         self.notify_event(
                             "reap",


### PR DESCRIPTION
If a restart or stop is issued via circusctl, it is perfectly reasonable
that a watched process will already be reaped.

See https://github.com/mozilla-services/circus/issues/658
