### PR TITLE
commands:  add spawn

### DIFF
--- a/circus/commands/__init__.py
+++ b/circus/commands/__init__.py
@@ -18,6 +18,7 @@ from circus.commands import (   # NOQA
     rmwatcher,
     sendsignal,
     set,
+    spawn,
     start,
     stats,
     status,

--- a/circus/commands/spawn.py
+++ b/circus/commands/spawn.py
@@ -1,0 +1,56 @@
+from circus.commands.base import Command
+from circus.exc import ArgumentError
+
+
+class Spawn(Command):
+    """\
+        Spawn processes for the specified watcher.
+        ==============================
+
+        This command instructs the specified watcher to ensure that the
+        configured (numprocesses) number of processes are spawned.  This can be
+        used to bring all the processes for a watcher back up if automatic
+        respawn was not enabled.
+
+
+        ZMQ Message
+        -----------
+
+        ::
+
+            {
+                "command": "spawn",
+                "properties": {
+                    "name": '<name>",
+                }
+            }
+
+        The request must include the name of the watcher that should spawn
+        processes.
+
+        The response returns the status "ok".
+
+        Command line
+        ------------
+
+        ::
+
+            $ circusctl spawn <name>
+
+        Options
+        +++++++
+
+        - <name>: name of the watcher
+
+    """
+    name = "spawn"
+
+    def message(self, *args, **opts):
+        if len(args) != 1:
+            raise ArgumentError("invalid number of arguments")
+
+        return self.make_message(name=args[0])
+
+    def execute(self, arbiter, props):
+        watcher = self._get_watcher(arbiter, props['name'])
+        return watcher.spawn_processes()

--- a/circus/tests/test_command_spawn.py
+++ b/circus/tests/test_command_spawn.py
@@ -1,0 +1,61 @@
+from circus.commands.spawn import Spawn
+from circus.exc import ArgumentError
+from circus.tests.support import TestCircus, EasyTestSuite
+
+
+class FakeWatcher(object):
+    def __init__(self):
+        self.running = 0
+        self.numprocesses = 2
+
+    def spawn_processes(self):
+        self.running = self.numprocesses
+
+
+class FakeLoop(object):
+    def add_callback(self, function):
+        function()
+
+
+class FakeArbiter(object):
+    watcher_class = FakeWatcher
+
+    def __init__(self):
+        self.watchers = [self.watcher_class()]
+        self.loop = FakeLoop()
+
+    def get_watcher(self, name):
+        return self.watchers[0]
+
+    def stop_watchers(self, **options):
+        self.watchers[:] = []
+
+    def stop(self, **options):
+        self.stop_watchers(**options)
+
+
+class SpawnTest(TestCircus):
+    def test_spawn(self):
+        cmd = Spawn()
+        arbiter = FakeArbiter()
+        self.assertEqual(arbiter.watchers[0].running, 0)
+        self.assertNotEqual(
+            arbiter.watchers[0].running,
+            arbiter.watchers[0].numprocesses)
+
+        props = cmd.message('dummy')['properties']
+        cmd.execute(arbiter, props)
+
+        self.assertEqual(
+            arbiter.watchers[0].running,
+            arbiter.watchers[0].numprocesses)
+
+    def test_exceptions(self):
+        cmd = Spawn()
+        with self.assertRaises(ArgumentError):
+            cmd.message()
+
+        with self.assertRaises(ArgumentError):
+            cmd.message(1, 2)
+
+test_suite = EasyTestSuite(__name__)


### PR DESCRIPTION
Add ability to be able to schedule a call to spawn_processes for a
specified watcher.  This is useful when running watchers where one has
respawn=False but still wants to have the ability to respawn from a
circus client.
