### PR TITLE
DO NOT MERGE: When creating a stream, check for class before filename

### DIFF
--- a/circus/stream/__init__.py
+++ b/circus/stream/__init__.py
@@ -77,13 +77,11 @@ class FancyStdoutStream(StdoutStream):
     # Generate a datetime object
     now = datetime.now
 
-    def __init__(self, color=None, time_format=None, *args, **kwargs):
+    def __init__(self, color=None, time_format=None, **kwargs):
+        super(FancyStdoutStream, self).__init__(**kwargs)
         self.time_format = time_format or '%Y-%m-%d %H:%M:%S'
-
-        # If no color is provided we pick one at random
         if color not in self.colors:
             color = random.choice(self.colors)
-
         self.color_code = self.colors.index(color) + 1
 
     def prefix(self, pid):
@@ -119,15 +117,15 @@ def get_stream(conf):
         return conf
 
     # we can have 'stream' or 'class' or 'filename'
-    if 'filename' in conf:
-        inst = FileStream(**conf)
-    elif 'stream' in conf:
-        inst = conf['stream']
-    elif 'class' in conf:
+    if 'class' in conf:
         class_name = conf.pop('class')
         if not "." in class_name:
             class_name = "circus.stream.%s" % class_name
         inst = resolve_name(class_name)(**conf)
+    elif 'stream' in conf:
+        inst = conf['stream']
+    elif 'filename' in conf:
+        inst = FileStream(**conf)
     else:
         raise ValueError("stream configuration invalid")
 


### PR DESCRIPTION
Bug fix. When creating a `stream`, check for `class` before `filename` so classes can have the filename parameter. Unexpected behavior occurred in the following case:

```
[watcher:aack]
....
stdout_stream.class = my.custom.LogHandler
stdout_stream.filename = /my/log/path.txt
```

Despite specifying a custom class, **circusd** would always create a `FileStream`.
