### PR TITLE
Eliminate unnecessary reload of arbiter

### DIFF
--- a/circus/circusd.py
+++ b/circus/circusd.py
@@ -140,7 +140,7 @@ def main():
     restart = True
     while restart:
         try:
-            arbiter = Arbiter.load_from_config(args.config)
+            arbiter = arbiter or Arbiter.load_from_config(args.config)
             future = arbiter.start()
             restart = False
             if check_future_exception_and_log(future) is None:
@@ -152,6 +152,7 @@ def main():
         except KeyboardInterrupt:
             pass
         finally:
+            arbiter = None
             if pidfile is not None:
                 pidfile.unlink()
     sys.exit(0)


### PR DESCRIPTION
Arbiter was being constructed, including output objects, then constructed again. This simple change eliminates the extra construction.
