### PR TITLE
Fix typo in reload

### DIFF
--- a/circus/stream/__init__.py
+++ b/circus/stream/__init__.py
@@ -123,7 +123,7 @@ def get_stream(conf, reload=False):
             cls = globals()[class_name]
             inst = cls(**conf)
         else:
-            inst = resolve_name(class_name, reload=reload())(**conf)
+            inst = resolve_name(class_name, reload=reload)(**conf)
     elif 'stream' in conf:
         inst = conf['stream']
     elif 'filename' in conf:


### PR DESCRIPTION
Accidentally did `reload()` instead of just `reload`. No unit tests failed. Hmm....
