### PR TITLE
Fix type of priority in plugin config

### DIFF
--- a/circus/config.py
+++ b/circus/config.py
@@ -194,6 +194,8 @@ def get_config(config_file):
         if section.startswith("plugin:"):
             plugin = dict(cfg.items(section))
             plugin['name'] = section
+            if 'priority' in plugin:
+                plugin['priority'] = int(plugin['priority'])
             plugins.append(plugin)
 
         if section.startswith("watcher:"):

--- a/circus/tests/config/issue680.ini
+++ b/circus/tests/config/issue680.ini
@@ -1,0 +1,17 @@
+[circus]
+check_delay = -1
+
+[watcher:test1]
+cmd = sleep 10
+numprocesses = 2
+priority = 10
+
+[watcher:test2]
+cmd = sleep 20
+numprocesses = 2
+priority = 20
+
+[plugin:myplugin]
+use = circus.plugins.resource_watcher.ResourceWatcher
+watcher = test1
+priority = 30

--- a/circus/tests/test_config.py
+++ b/circus/tests/test_config.py
@@ -3,6 +3,7 @@ import signal
 from mock import patch
 
 from circus import logger
+from circus.arbiter import Arbiter
 from circus.config import get_config
 from circus.watcher import Watcher
 from circus.process import Process
@@ -38,7 +39,8 @@ _CONF = {
     'issue594': os.path.join(CONFIG_DIR, 'issue594.ini'),
     'reuseport': os.path.join(CONFIG_DIR, 'reuseport.ini'),
     'issue651': os.path.join(CONFIG_DIR, 'issue651.ini'),
-    'issue665': os.path.join(CONFIG_DIR, 'issue665.ini')
+    'issue665': os.path.join(CONFIG_DIR, 'issue665.ini'),
+    'issue680': os.path.join(CONFIG_DIR, 'issue680.ini'),
 }
 
 
@@ -188,6 +190,16 @@ class TestConfig(TestCase):
         conf = get_config(_CONF['issue210'])
         watcher = Watcher.load_from_config(conf['watchers'][0])
         watcher.stop()
+
+    def test_plugin_priority(self):
+        arbiter = Arbiter.load_from_config(_CONF['issue680'])
+        watchers = arbiter.iter_watchers()
+        self.assertEqual(watchers[0].priority, 30)
+        self.assertEqual(watchers[0].name, 'plugin:myplugin')
+        self.assertEqual(watchers[1].priority, 20)
+        self.assertEqual(watchers[1].cmd, 'sleep 20')
+        self.assertEqual(watchers[2].priority, 10)
+        self.assertEqual(watchers[2].cmd, 'sleep 10')
 
     def test_hooks(self):
         conf = get_config(_CONF['hooks'])


### PR DESCRIPTION
If priority was set in the config section of a plugin, it's type was not converted to int. I have included a unit test for this.
