### PR TITLE
Better manage watchers

### DIFF
--- a/circus/arbiter.py
+++ b/circus/arbiter.py
@@ -597,7 +597,8 @@ class Arbiter(object):
             if watcher.on_demand and watcher.is_stopped():
                 need_on_demand = True
             list_to_yield.append(watcher.manage_processes())
-        yield list_to_yield
+        if len(list_to_yield) > 0:
+            yield list_to_yield
 
         if need_on_demand:
             sockets = [x.fileno() for x in self.sockets.values()]


### PR DESCRIPTION
Better concurrency in manage_watchers() method.

Useful if you have plenty of watchers with a max_age and a big graceful_timeout (for example)
