### PR TITLE
Allow INI/JSON/YAML configuration for logging

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,7 @@
 omit = *_patch*,circus/tests/*
 source = circus
 include = circus/*
+parallel = true
 
 [html]
 directory = html

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -86,3 +86,4 @@ List of contributors:
 - Dong Weiming <ciici123@gmail.com>
 - Wynn Wilkes <wynnwilkes@gmail.com>
 - Sylvain Viollon <sviollon@minddistrict.com>
+- James Ascroft-Leigh <jwal@jwal.me.uk>

--- a/circus/arbiter.py
+++ b/circus/arbiter.py
@@ -85,8 +85,8 @@ class Arbiter(object):
                  httpd_host='localhost', httpd_port=8080,
                  httpd_close_outputs=False, debug=False, debug_gc=False,
                  ssh_server=None, proc_name='circusd', pidfile=None,
-                 loglevel=None, logoutput=None, fqdn_prefix=None, umask=None,
-                 endpoint_owner=None):
+                 loglevel=None, logoutput=None, loggerconfig=None,
+                 fqdn_prefix=None, umask=None, endpoint_owner=None):
 
         self.watchers = watchers
         self.endpoint = endpoint
@@ -100,6 +100,7 @@ class Arbiter(object):
         self.pidfile = pidfile
         self.loglevel = loglevel
         self.logoutput = logoutput
+        self.loggerconfig = loggerconfig
         self.umask = umask
         self.endpoint_owner = endpoint_owner
         self._running = False
@@ -445,6 +446,7 @@ class Arbiter(object):
                       pidfile=cfg.get('pidfile', None),
                       loglevel=cfg.get('loglevel', None),
                       logoutput=cfg.get('logoutput', None),
+                      loggerconfig=cfg.get('loggerconfig', None),
                       fqdn_prefix=cfg.get('fqdn_prefix', None),
                       umask=cfg['umask'],
                       endpoint_owner=cfg.get('endpoint_owner', None))

--- a/circus/circusd.py
+++ b/circus/circusd.py
@@ -87,6 +87,10 @@ def main():
         "The location where the logs will be written. The default behavior "
         "is to write to stdout (you can force it by passing '-' to "
         "this option). Takes a filename otherwise."))
+    parser.add_argument("--logger-config", dest="loggerconfig", help=(
+        "The location where a standard Python logger configuration INI, "
+        "JSON or YAML file can be found.  This can be used to override "
+        "the default logging configuration for the arbiter."))
 
     parser.add_argument('--daemon', dest='daemonize', action='store_true',
                         help="Start circusd in the background")
@@ -128,7 +132,8 @@ def main():
     # configure the logger
     loglevel = args.loglevel or arbiter.loglevel or 'info'
     logoutput = args.logoutput or arbiter.logoutput or '-'
-    configure_logger(logger, loglevel, logoutput)
+    loggerconfig = args.loggerconfig or arbiter.loggerconfig or None
+    configure_logger(logger, loglevel, logoutput, loggerconfig)
 
     # Main loop
     restart = True

--- a/circus/config.py
+++ b/circus/config.py
@@ -167,6 +167,7 @@ def get_config(config_file):
     config['pidfile'] = dget('circus', 'pidfile')
     config['loglevel'] = dget('circus', 'loglevel')
     config['logoutput'] = dget('circus', 'logoutput')
+    config['loggerconfig'] = dget('circus', 'loggerconfig', None)
     config['fqdn_prefix'] = dget('circus', 'fqdn_prefix', None, str)
 
     # Initialize watchers, plugins & sockets to manage

--- a/circus/tests/test_logging.py
+++ b/circus/tests/test_logging.py
@@ -1,0 +1,257 @@
+try:
+    from io import StringIO
+    from io import BytesIO
+except ImportError:
+    from cStringIO import StringIO  # NOQA
+try:
+    from configparser import ConfigParser
+except ImportError:
+    from ConfigParser import ConfigParser  # NOQA
+from circus.tests.support import TestCase
+from circus.tests.support import EasyTestSuite
+from circus.tests.support import skipIf
+import os
+import shutil
+import tempfile
+from pipes import quote as shell_escape_arg
+import subprocess
+import time
+import yaml
+import json
+import logging.config
+import sys
+
+
+HERE = os.path.abspath(os.path.dirname(__file__))
+CONFIG_PATH = os.path.join(HERE, 'config', 'circus.ini')
+
+
+def run_circusd(options=(), config=(), log_capture_path="log.txt",
+                additional_files=()):
+    options = list(options)
+    additional_files = dict(additional_files)
+    config_ini_update = {
+        "watcher:touch.cmd": ("bash -c 'touch workerstart.txt; "
+                              "while true; do sleep 0.1; done'"),
+    }
+    config_ini_update.update(dict(config))
+    config_ini = ConfigParser()
+    config_ini.read(CONFIG_PATH)
+    for dottedkey in config_ini_update:
+        section, key = dottedkey.split(".", 1)
+        if section not in config_ini.sections():
+            config_ini.add_section(section)
+        config_ini.set(
+            section, key, config_ini_update[dottedkey])
+    temp_dir = tempfile.mkdtemp()
+    try:
+        circus_ini_path = os.path.join(temp_dir, "circus.ini")
+        with open(circus_ini_path, "w") as fh:
+            config_ini.write(fh)
+        for relpath in additional_files:
+            path = os.path.join(temp_dir, relpath)
+            with open(path, "w") as fh:
+                fh.write(additional_files[relpath])
+        # argv2 = ["cat", "circus.ini"]
+        # subprocess.check_call(argv2, cwd=temp_dir)
+        argv = ["circus.circusd"] + options + [circus_ini_path]
+        if sys.gettrace() is None:
+            argv = ["python", "-m"] + argv
+        else:
+            argv = ["coverage", "run", "-p", "-m"] + argv
+        # print "+", " ".join(shell_escape_arg(a) for a in argv)
+        child = subprocess.Popen(argv, cwd=temp_dir, stdin=subprocess.PIPE,
+                                 stdout=subprocess.PIPE,
+                                 stderr=subprocess.STDOUT)
+        try:
+            touch_path = os.path.join(temp_dir, "workerstart.txt")
+            # subprocess.call(["bash"], cwd=temp_dir)
+            while True:
+                child.poll()
+                if os.path.exists(touch_path):
+                    break
+                if child.returncode is not None:
+                    break
+                time.sleep(0.01)
+        finally:
+            argv2 = ["python", "-m", "circus.circusctl", "quit"]
+            subprocess.call(argv2, cwd=temp_dir, stdin=subprocess.PIPE,
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.STDOUT)
+            child.wait()
+        log_file_path = os.path.join(temp_dir, log_capture_path)
+        # raise Exception(child.stdout.read())
+        if os.path.exists(log_file_path):
+            with open(log_file_path, "r") as fh:
+                return fh.read()
+        else:
+            if child.stdout is not None:
+                raise Exception(child.stdout.read().decode("ascii"))
+        assert child.returncode == 0, \
+            " ".join(shell_escape_arg(a) for a in argv)
+    finally:
+        for basename in sorted(os.listdir(temp_dir)):
+            if basename.startswith(".coverage."):
+                source = os.path.join(temp_dir, basename)
+                target = os.path.abspath(basename)
+                shutil.copy(source, target)
+        shutil.rmtree(temp_dir)
+
+EXAMPLE_YAML = """\
+version: 1
+disable_existing_loggers: false
+formatters:
+  simple:
+    format: '%(asctime)s - %(name)s - [%(levelname)s] %(message)s'
+handlers:
+  logfile:
+    class: logging.FileHandler
+    filename: logoutput.txt
+    level: DEBUG
+    formatter: simple
+loggers:
+  circus:
+    level: DEBUG
+    handlers: [logfile]
+    propagate: no
+root:
+  level: DEBUG
+  handlers: [logfile]
+"""
+
+EXPECTED_LOG_MESSAGE = "[INFO] Arbiter now waiting for commands"
+
+
+def logging_dictconfig_to_ini(config):
+    assert config.get("version", 1) == 1, config
+    ini = ConfigParser()
+    ini.add_section("loggers")
+    loggers = config.get("loggers", {})
+    if "root" in config:
+        loggers["root"] = config["root"]
+    ini.set("loggers", "keys", ",".join(sorted(loggers.keys())))
+    for logger in sorted(loggers.keys()):
+        section = "logger_%s" % (logger.replace(".", "_"),)
+        ini.add_section(section)
+        for key, value in sorted(loggers[logger].items()):
+            if key == "handlers":
+                value = ",".join(value)
+            if key == "propagate":
+                value = "1" if value else "0"
+            ini.set(section, key, value)
+        ini.set(section, "qualname", logger)
+    ini.add_section("handlers")
+    handlers = config.get("handlers", {})
+    ini.set("handlers", "keys", ",".join(sorted(handlers.keys())))
+    for handler in sorted(handlers.keys()):
+        section = "handler_%s" % (handler,)
+        ini.add_section(section)
+        args = []
+        for key, value in sorted(handlers[handler].items()):
+            if (handlers[handler]["class"] == "logging.FileHandler"
+                    and key == "filename"):
+                args.append(value)
+            else:
+                ini.set(section, key, value)
+        ini.set(section, "args", repr(tuple(args)))
+    ini.add_section("formatters")
+    formatters = config.get("formatters", {})
+    ini.set("formatters", "keys", ",".join(sorted(formatters.keys())))
+    for formatter in sorted(formatters.keys()):
+        section = "formatter_%s" % (formatter,)
+        ini.add_section(section)
+        for key, value in sorted(formatters[formatter].items()):
+            ini.set(section, key, value)
+    try:
+        # Older Python (without io.StringIO/io.BytesIO) and Python 3 use
+        # this code path.
+        result = StringIO()
+        ini.write(result)
+        return result.getvalue()
+    except TypeError:
+        # Python 2.7 has io.StringIO and io.BytesIO but ConfigParser.write
+        # has not been fixed to work with StringIO.
+        result = BytesIO()
+        ini.write(result)
+        return result.getvalue().decode("ascii")
+
+
+def hasDictConfig():
+    return hasattr(logging.config, "dictConfig")
+
+
+class TestLoggingConfig(TestCase):
+
+    def test_loggerconfig_default_ini(self):
+        logs = run_circusd(
+            [], {"circus.logoutput": "log_ini.txt"},
+            log_capture_path="log_ini.txt")
+        self.assertTrue(EXPECTED_LOG_MESSAGE in logs, logs)
+
+    def test_loggerconfig_default_opt(self):
+        logs = run_circusd(
+            ["--log-output", "log_opt.txt"], {},
+            log_capture_path="log_opt.txt")
+        self.assertTrue(EXPECTED_LOG_MESSAGE in logs, logs)
+
+    @skipIf(not hasDictConfig(), "Needs logging.config.dictConfig()")
+    def test_loggerconfig_yaml_ini(self):
+        config = yaml.load(EXAMPLE_YAML)
+        config["handlers"]["logfile"]["filename"] = "log_yaml_ini.txt"
+        logs = run_circusd(
+            [], {"circus.loggerconfig": "logging.yaml"},
+            log_capture_path="log_yaml_ini.txt",
+            additional_files={"logging.yaml": yaml.dump(config)})
+        self.assertTrue(EXPECTED_LOG_MESSAGE in logs, logs)
+
+    @skipIf(not hasDictConfig(), "Needs logging.config.dictConfig()")
+    def test_loggerconfig_yaml_opt(self):
+        config = yaml.load(EXAMPLE_YAML)
+        config["handlers"]["logfile"]["filename"] = "log_yaml_opt.txt"
+        logs = run_circusd(
+            ["--logger-config", "logging.yaml"], {},
+            log_capture_path="log_yaml_opt.txt",
+            additional_files={"logging.yaml": yaml.dump(config)})
+        self.assertTrue(EXPECTED_LOG_MESSAGE in logs, logs)
+
+    @skipIf(not hasDictConfig(), "Needs logging.config.dictConfig()")
+    def test_loggerconfig_json_ini(self):
+        config = yaml.load(EXAMPLE_YAML)
+        config["handlers"]["logfile"]["filename"] = "log_json_ini.txt"
+        logs = run_circusd(
+            [], {"circus.loggerconfig": "logging.json"},
+            log_capture_path="log_json_ini.txt",
+            additional_files={"logging.json": json.dumps(config)})
+        self.assertTrue(EXPECTED_LOG_MESSAGE in logs, logs)
+
+    @skipIf(not hasDictConfig(), "Needs logging.config.dictConfig()")
+    def test_loggerconfig_json_opt(self):
+        config = yaml.load(EXAMPLE_YAML)
+        config["handlers"]["logfile"]["filename"] = "log_json_opt.txt"
+        logs = run_circusd(
+            ["--logger-config", "logging.json"], {},
+            log_capture_path="log_json_opt.txt",
+            additional_files={"logging.json": json.dumps(config)})
+        self.assertTrue(EXPECTED_LOG_MESSAGE in logs, logs)
+
+    def test_loggerconfig_ini_ini(self):
+        config = yaml.load(EXAMPLE_YAML)
+        config["handlers"]["logfile"]["filename"] = "log_ini_ini.txt"
+        logs = run_circusd(
+            [], {"circus.loggerconfig": "logging.ini"},
+            log_capture_path="log_ini_ini.txt",
+            additional_files={
+                "logging.ini": logging_dictconfig_to_ini(config)})
+        self.assertTrue(EXPECTED_LOG_MESSAGE in logs, logs)
+
+    def test_loggerconfig_ini_opt(self):
+        config = yaml.load(EXAMPLE_YAML)
+        config["handlers"]["logfile"]["filename"] = "log_ini_opt.txt"
+        logs = run_circusd(
+            ["--logger-config", "logging.ini"], {},
+            log_capture_path="log_ini_opt.txt",
+            additional_files={
+                "logging.ini": logging_dictconfig_to_ini(config)})
+        self.assertTrue(EXPECTED_LOG_MESSAGE in logs, logs)
+
+test_suite = EasyTestSuite(__name__)

--- a/docs/source/for-ops/configuration.rst
+++ b/docs/source/for-ops/configuration.rst
@@ -116,6 +116,11 @@ circus - single section
         syslog facility to use. If you wish to log to a local syslog
         you can use ``syslog:///path/to/syslog/socket?facility``
         instead.
+    **loggerconfig**
+        A path to an INI, JSON or YAML file to configure standard Python
+        logging for the Arbiter.  The special value "default" uses the builtin
+	logging configuration based on the optional loglevel and logoutput
+	options.
 
 
 watcher:NAME - as many sections as you want

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,3 +6,4 @@ python-coveralls==2.4.0
 nose-cov==1.6
 coverage==3.7
 randomize==0.9
+PyYAML==3.10

--- a/tox.ini
+++ b/tox.ini
@@ -49,6 +49,8 @@ setenv =
 commands =
     python setup.py develop
     nosetests --randomize -x --with-coverage --cover-package=circus circus/tests
+    coverage combine
+    coverage html
 
 [testenv:docs]
 whitelist_externals = make


### PR DESCRIPTION
Hi,

I noticed https://github.com/mozilla-services/circus/issues/366 and I wondered whether something like this would be a viable approach.  I have an example syslog configuration file that seems to work with this patch: https://gist.github.com/jwal/8258682

The idea is that you can use the --logger-config option on circusd (or the loggerconfig option in the circus section of the circus.ini file) to provide the path to a logging configuration file in a standard Python format.  The full description for this configuration file format is here: http://docs.python.org/2/howto/logging.html

Thoughts?  Questions? Ideas?

Regards,

James
