### PR TITLE
Fix #714

### DIFF
--- a/circus/util.py
+++ b/circus/util.py
@@ -849,6 +849,8 @@ def synchronized(name):
             elif hasattr(self, "_exclusive_running_command"):
                 arbiter = self
             if arbiter is not None:
+                if arbiter._restarting:
+                    raise ConflictError("arbiter is restarting...")
                 if arbiter._exclusive_running_command is not None:
                     raise ConflictError("arbiter is already running %s command"
                                         % arbiter._exclusive_running_command)


### PR DESCRIPTION
No concurrent execution during arbiter restart

An explicit test is needed because the restart()
command is a kind of stop() command. The start after
the stop is made (externally) by circusd for plenty of reasons.

So the restart() command is over before the arbiter is really restarted.
So the classic synchronized decorator is released too early.

see #714
