### PR TITLE
Getting children PIDs before the main process is killed

### DIFF
--- a/circus/watcher.py
+++ b/circus/watcher.py
@@ -611,6 +611,8 @@ class Watcher(object):
 
         The signal is sent to the process itself then to all the children
         """
+        # getting the children list before the main process may be stopped
+        children_pids = process.children()
         try:
             # sending the signal to the process itself
             self.send_signal(process.pid, signum)
@@ -620,7 +622,7 @@ class Watcher(object):
             # already dead !
             pass
         # now sending the same signal to all the children
-        for child_pid in process.children():
+        for child_pid in children_pids:
             try:
                 process.send_signal_child(child_pid, signum)
                 self.notify_event("kill", {"process_pid": child_pid,


### PR DESCRIPTION
List of children processes cannot be obtained after the main process has stopped, so to actually ensure that children processes are also signaled, even when signal causes main process to stop, we must get their PIDs first.
