### PR TITLE
Feature/watched file handler

### DIFF
--- a/circus/plugins/__init__.py
+++ b/circus/plugins/__init__.py
@@ -245,7 +245,7 @@ def main():
     if args.logoutput == "-":
         h = logging.StreamHandler()
     else:
-        h = logging.FileHandler(args.logoutput)
+        h = logging.handlers.WatchedFileHandler(args.logoutput)
         close_on_exec(h.stream.fileno())
     fmt = logging.Formatter(LOG_FMT, LOG_DATE_FMT)
     h.setFormatter(fmt)

--- a/circus/stats/__init__.py
+++ b/circus/stats/__init__.py
@@ -12,6 +12,7 @@ Stats architecture:
 import sys
 import argparse
 import logging
+import logging.handlers
 
 from circus.stats.streamer import StatsStreamer
 from circus import logger
@@ -71,7 +72,7 @@ def main():
     if args.logoutput == "-":
         h = logging.StreamHandler()
     else:
-        h = logging.FileHandler(args.logoutput)
+        h = logging.handlers.WatchedFileHandler(args.logoutput)
         util.close_on_exec(h.stream.fileno())
     fmt = logging.Formatter(LOG_FMT, LOG_DATE_FMT)
     h.setFormatter(fmt)

--- a/circus/stream/__init__.py
+++ b/circus/stream/__init__.py
@@ -9,6 +9,7 @@ except ImportError:
 
 from circus.util import resolve_name
 from circus.stream.file_stream import FileStream
+from circus.stream.file_stream import WatchedFileStream  # flake8: noqa
 from circus.stream.redirector import Redirector
 from circus.py3compat import s
 

--- a/circus/util.py
+++ b/circus/util.py
@@ -584,7 +584,7 @@ def configure_logger(logger, level='INFO', output="-"):
     if output == "-":
         h = logging.StreamHandler()
     else:
-        h = logging.FileHandler(output)
+        h = logging.handlers.WatchedFileHandler(output)
         close_on_exec(h.stream.fileno())
     fmt = logging.Formatter(LOG_FMT, LOG_DATE_FMT)
     h.setFormatter(fmt)

--- a/circus/watcher.py
+++ b/circus/watcher.py
@@ -80,10 +80,11 @@ class Watcher(object):
         `circus.stream.FileStream`
       - **filename**: the filename, if using a FileStream
       - **max_bytes**: maximum file size, after which a new output file is
-        opened. defaults to 0 which means no maximum size.
+        opened. defaults to 0 which means no maximum size (only applicable
+        with FileStream).
       - **backup_count**: how many backups to retain when rotating files
         according to the max_bytes parameter. defaults to 0 which means
-        no backups are made.
+        no backups are made (only applicable with FileStream)
 
       This mapping will be used to create a stream callable of the specified
       class.
@@ -101,10 +102,11 @@ class Watcher(object):
       - **class**: the stream class. Defaults to `circus.stream.FileStream`
       - **filename**: the filename, if using a FileStream
       - **max_bytes**: maximum file size, after which a new output file is
-        opened. defaults to 0 which means no maximum size.
+        opened. defaults to 0 which means no maximum size (only applicable
+        with FileStream)
       - **backup_count**: how many backups to retain when rotating files
         according to the max_bytes parameter. defaults to 0 which means
-        no backups are made.
+        no backups are made (only applicable with FileStream).
 
       This mapping will be used to create a stream callable of the specified
       class.

--- a/docs/source/for-ops/configuration.rst
+++ b/docs/source/for-ops/configuration.rst
@@ -124,7 +124,7 @@ watcher:NAME - as many sections as you want
         If True, the processes are run in the shell (default: False)
     **shell_args**
         Command-line arguments to pass to the shell command when **shell** is
-        True. Works only for *nix system (default: None)
+        True. Works only for \*nix system (default: None)
     **working_dir**
         The working dir for the processes (default: None)
     **uid**
@@ -162,7 +162,8 @@ watcher:NAME - as many sections as you want
 
         Circus provides some stream classes you can use without prefix:
 
-        - :class:`FileStream`: writes in a file
+        - :class:`FileStream`: writes in a file and can do automatic log rotation
+        - :class:`WatchedFileStream`: writes in a file and relies on external log rotation
         - :class:`QueueStream`: write in a memory Queue
         - :class:`StdoutStream`: writes in the stdout
         - :class:`FancyStdoutStream`: writes colored output with time prefixes in the stdout
@@ -176,9 +177,10 @@ watcher:NAME - as many sections as you want
         will receive the **stdout** stream of all processes in its
         :func:`__call__` method.
 
-        Circus provides soem stream classes you can use without prefix:
+        Circus provides some stream classes you can use without prefix:
 
-        - :class:`FileStream`: writes in a file
+        - :class:`FileStream`: writes in a file and can do automatic log rotation
+        - :class:`WatchedFileStream`: writes in a file and relies on external log rotation
         - :class:`QueueStream`: write in a memory Queue
         - :class:`StdoutStream`: writes in the stdout
         - :class:`FancyStdoutStream`: writes colored output with time prefixes in the stdout
@@ -565,8 +567,39 @@ Example:
     stdout_stream.backup_count = 5
 
 
-FancyStdoutStram
-::::::::::::::::
+WatchedFileStream
+:::::::::::::::::
+
+    **filename**
+        The file path where log will be written.
+
+    **time_format**
+        The strftime format that will be used to prefix each time with a timestamp.
+        By default they will be not prefixed.
+
+        i.e: %Y-%m-%d %H:%M:%S
+
+.. note::
+
+    WatchedFileStream relies on an external log rotation tool to ensure that
+    log files don't become too big. The output file will be monitored and if
+    it is ever deleted or moved by the external log rotation tool, then the
+    output file handle will be automatically reloaded.
+
+Example:
+
+.. code-block:: ini
+
+    [watcher:myprogram]
+    cmd = python -m myapp.server
+
+    stdout_stream.class = WatchedFileStream
+    stdout_stream.filename = test.log
+    stdout_stream.time_format = %Y-%m-%d %H:%M:%S
+
+
+FancyStdoutStream
+:::::::::::::::::
 
     **color**
         The name of an ascii color:

--- a/docs/source/tutorial/rationale.rst
+++ b/docs/source/tutorial/rationale.rst
@@ -128,7 +128,7 @@ tool does not have a **tail** feature like in Supervisor, but will let
 you hook any piece of code to deal with the incoming stream. You
 can create your own stream hook (as a Class) and do whatever you want with
 the incoming stream. Circus provides some built-in stream classes
-like **StdoutStream** or **FileStream**.
+like **StdoutStream**, **FileStream**, or **WatchedFileStream**.
 
 .. XXX add more complex examples
 


### PR DESCRIPTION
This pull request is focused on allowing a circus environment to work better with an external log rotation utility. I've got a mix of processes from different languages and different logging libraries, and it's a lot easier to get all of them to work with an external log rotation utility than to get all the logging libraries to do automatic log rotation.

The new WatchedFileStream makes all the stdout/stderr streams work that way, and using the WatchedFileHandler makes the circusd logs work better.

This also contains a fix for the reap message to make it so that a plugin watching for reap messages can distinguish between a non-zero exit and a signal'd exit by following the same pattern that the builtin Python Popen.returncode uses to distinguish between the two.

All tests are passing for me and I've tested the new functionality hard with my projects, so it should be very stable. The docs have been updated as well.
