### PR TITLE
Add systemd example to the deployment documentation for ops

### DIFF
--- a/docs/source/for-ops/deployment.rst
+++ b/docs/source/for-ops/deployment.rst
@@ -21,7 +21,35 @@ create this Upstart script in /etc/init/circus.conf.
 This assumes that circus.ini is located at /etc/circus.ini. After
 rebooting, you can control circusd with the service command::
 
-    $ service circus start/stop/restart
+    # service circus start/stop/restart
+
+If your system supports systemd, you can create this systemd unit file under
+/etc/systemd/system/circus.service.
+
+::
+
+   [Unit]
+   Description=Circus process manager
+   After=syslog.target network.target nss-lookup.target
+
+   [Service]
+   Type=simple
+   ExecReload=/usr/bin/circusctl reload
+   ExecStart=/usr/bin/circusd /etc/circus/circus.ini
+   Restart=always
+   RestartSec=5
+
+   [Install]
+   WantedBy=default.target
+
+A reboot isn't required if you run the daemon-reload command below::
+
+    # systemctl --system daemon-reload
+
+Then circus can be managed via::
+
+    # systemctl start/stop/status/reload circus
+
 
 Recipes
 =======


### PR DESCRIPTION
Since the Debian fiasco and Mark Shuttleworth admitted Ubuntu will be forced to transition to systemd, it seemed fitting to add my example unit file to the circus docs.

When I get a bit more free time, I'll likely work on a native circus package for Fedora and EPEL for RHEL and the derivatives. 
