### PR TITLE
Add ipython shell command

### DIFF
--- a/circus/commands/__init__.py
+++ b/circus/commands/__init__.py
@@ -5,6 +5,7 @@ from circus.commands import (   # NOQA
     get,
     globaloptions,
     incrproc,
+    ipythonshell,
     list,
     listen,
     listsockets,

--- a/circus/commands/base.py
+++ b/circus/commands/base.py
@@ -65,15 +65,16 @@ class Command(object):
     waiting_options = [('waiting', 'waiting', False,
                         "Waiting the real end of the process")]
 
+    ##################################################
+    # These methods run within the circusctl process #
+    ##################################################
+
     def make_message(self, **props):
         name = props.pop("command", self.name)
         return {"command": name, "properties": props or {}}
 
     def message(self, *args, **opts):
         raise NotImplementedError("message function isn't implemented")
-
-    def execute(self, arbiter, props):
-        raise NotImplementedError("execute function is not implemented")
 
     def console_error(self, msg):
         return "error: %s" % msg.get("reason")
@@ -85,6 +86,13 @@ class Command(object):
 
     def copy(self):
         return copy.copy(self)
+
+    ################################################
+    # These methods run within the circusd process #
+    ################################################
+
+    def execute(self, arbiter, props):
+        raise NotImplementedError("execute function is not implemented")
 
     def _get_watcher(self, arbiter, watcher_name):
         """Get watcher from the arbiter if any."""

--- a/circus/commands/ipythonshell.py
+++ b/circus/commands/ipythonshell.py
@@ -1,0 +1,63 @@
+import os
+import sys
+from circus.exc import ArgumentError
+from circus.commands.base import Command
+
+
+class IPythonShell(Command):
+    """\
+       Create shell into circusd process
+       =================================
+
+       This command is only useful if you have the ipython package installed.
+
+       Command Line
+       ------------
+
+       ::
+
+            $ circusctl ipython
+
+    """
+
+    name = "ipython"
+
+    def message(self, *args, **opts):
+        if len(args) > 0:
+            raise ArgumentError("Invalid message")
+        return self.make_message()
+
+    def execute(self, arbiter, props):
+        shell = 'kernel-%d.json' % os.getpid()
+        msg = None
+        try:
+            from IPython.kernel.zmq.kernelapp import IPKernelApp
+            if not IPKernelApp.initialized():
+                app = IPKernelApp.instance()
+                app.initialize([])
+                main = app.kernel.shell._orig_sys_modules_main_mod
+                if main is not None:
+                    sys.modules[
+                        app.kernel.shell._orig_sys_modules_main_name
+                    ] = main
+                app.kernel.user_module = sys.modules[__name__]
+                app.kernel.user_ns = {'arbiter': arbiter}
+                app.shell.set_completer_frame()
+                app.kernel.start()
+
+        except Exception as e:
+            shell = False
+            msg = str(e)
+
+        return {'shell': shell, 'msg': msg}
+
+    def console_msg(self, msg):
+        if msg['status'] == "ok":
+            shell = msg['shell']
+            if shell:
+                from IPython import start_ipython
+                start_ipython(['console', '--existing', shell])
+                return ''
+            else:
+                msg['reason'] = 'Could not start ipython kernel'
+        return self.console_error(msg)


### PR DESCRIPTION
This command allows you to start an IPython shell running directly in circusd. It exposes `arbiter` as a local variable, so you can do this, for instance:

```
> circusctl ipython
Python 3.3.3 (default, Nov 19 2013, 18:24:35)
Type "copyright", "credits" or "license" for more information.

IPython 1.2.0 -- An enhanced Interactive Python.
?         -> Introduction and overview of IPython's features.
%quickref -> Quick reference.
help      -> Python's own help system.
object?   -> Details about 'object', use 'object??' for extra details.

In [1]: arbiter.statuses()
Out[1]:
{'logger': 'active',
 'plugin:flapping': 'active',
 'plugin:monitor': 'active',
 'sf': 'active',
 'web-server': 'active'}

In [2]:
```

We are running into a memory leak at the moment in our circusd instances. We'll use this to connect to a greedy instance and inspect the `gc`.
