### PR TITLE
Case sensitive environment for watchers

### DIFF
--- a/circus/config.py
+++ b/circus/config.py
@@ -124,15 +124,12 @@ def get_config(config_file):
     config = {}
 
     # reading the global environ first
-    def _upper(items):
-        return [(key.upper(), value) for key, value in items]
-
-    global_env = dict(_upper(os.environ.items()))
+    global_env = dict(os.environ.items())
     local_env = dict()
 
     # update environments with [env] section
     if 'env' in cfg.sections():
-        local_env.update(dict(_upper(cfg.items('env'))))
+        local_env.update(dict(cfg.items('env')))
         global_env.update(local_env)
 
     # always set the cfg environment
@@ -281,7 +278,7 @@ def get_config(config_file):
         if section.startswith('env:'):
             section_elements = section.split("env:", 1)[1]
             watcher_patterns = [s.strip() for s in section_elements.split(',')]
-            env_items = dict(_upper(cfg.items(section, noreplace=True)))
+            env_items = dict(cfg.items(section, noreplace=True))
 
             for pattern in watcher_patterns:
                 match = [w for w in watchers if fnmatch(w['name'], pattern)]

--- a/circus/tests/config/env_sensecase.ini
+++ b/circus/tests/config/env_sensecase.ini
@@ -1,0 +1,14 @@
+[circus]
+check_delay = 5
+endpoint = tcp://127.0.0.1:5555
+pubsub_endpoint = tcp://127.0.0.1:5556
+stats_endpoint = tcp://127.0.0.1:5557
+statsd = True
+
+[watcher:webapp]
+cmd = curl
+
+[env:webapp]
+http_proxy = http://localhost:8080
+HTTPS_PROXY = http://localhost:8043
+FunKy_soUl = scorpio

--- a/circus/tests/test_config.py
+++ b/circus/tests/test_config.py
@@ -35,6 +35,7 @@ _CONF = {
     'issue546': os.path.join(CONFIG_DIR, 'issue546.ini'),
     'env_everywhere': os.path.join(CONFIG_DIR, 'env_everywhere.ini'),
     'copy_env': os.path.join(CONFIG_DIR, 'copy_env.ini'),
+    'env_sensecase': os.path.join(CONFIG_DIR, 'env_sensecase.ini'),
     'issue567': os.path.join(CONFIG_DIR, 'issue567.ini'),
     'issue594': os.path.join(CONFIG_DIR, 'issue594.ini'),
     'reuseport': os.path.join(CONFIG_DIR, 'reuseport.ini'),
@@ -316,6 +317,20 @@ class TestConfig(TestCase):
             else:
                 self.assertTrue('BAM' in watcher['env'])
             self.assertTrue('TEST1' in watcher['env'])
+
+    def test_env_casesense(self):
+        # #730 make sure respect case
+        conf = get_config(_CONF['env_sensecase'])
+        w = conf['watchers'][0]
+        self.assertEqual(w['name'], 'webapp')
+        self.assertTrue('http_proxy' in w['env'])
+        self.assertEqual(w['env']['http_proxy'], 'http://localhost:8080')
+
+        self.assertTrue('HTTPS_PROXY' in w['env'])
+        self.assertEqual(w['env']['HTTPS_PROXY'], 'http://localhost:8043')
+
+        self.assertTrue('FunKy_soUl' in w['env'])
+        self.assertEqual(w['env']['FunKy_soUl'], 'scorpio')
 
     def test_issue567(self):
         os.environ['GRAVITY'] = 'down'

--- a/circus/util.py
+++ b/circus/util.py
@@ -643,6 +643,7 @@ class StrictConfigParser(ConfigParser):
                         mo = self.OPTCRE.match(line)    # 2.6
                     if mo:
                         optname, vi, optval = mo.group('option', 'vi', 'value')
+                        self.optionxform = str
                         optname = self.optionxform(optname.rstrip())
                         # We don't want to override.
                         if optname in cursect:


### PR DESCRIPTION
watchers can inherit environment variables and not have them flattened to upper case.

libcurl allows for specifying an http proxy via: 'http_proxy' while 'HTTP_PROXY' is ignored

this fix allows for something like that
