### PR TITLE
Add support to log circus messages to syslog.

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -85,3 +85,4 @@ List of contributors:
 - Scott Maxwell <scott@codecobblers.com>
 - Dong Weiming <ciici123@gmail.com>
 - Wynn Wilkes <wynnwilkes@gmail.com>
+- Sylvain Viollon <sviollon@minddistrict.com>

--- a/circus/arbiter.py
+++ b/circus/arbiter.py
@@ -153,6 +153,10 @@ class Arbiter(object):
                 cmd += ' --ssh %s' % ssh_server
             if debug:
                 cmd += ' --log-level DEBUG'
+            elif self.loglevel:
+                cmd += ' --log-level ' + self.loglevel
+            if self.logoutput:
+                cmd += ' --log-output ' + self.logoutput
             stats_watcher = Watcher('circusd-stats', cmd, use_sockets=True,
                                     singleton=True,
                                     stdout_stream=self.stdout_stream,
@@ -199,7 +203,9 @@ class Arbiter(object):
                 fqn = plugin['use']
                 cmd = get_plugin_cmd(plugin, self.endpoint,
                                      self.pubsub_endpoint, self.check_delay,
-                                     ssh_server, debug=self.debug)
+                                     ssh_server, debug=self.debug,
+                                     loglevel=self.loglevel,
+                                     logoutput=self.logoutput)
                 plugin_cfg = dict(cmd=cmd, priority=1, singleton=True,
                                   stdout_stream=self.stdout_stream,
                                   stderr_stream=self.stderr_stream,

--- a/circus/stats/__init__.py
+++ b/circus/stats/__init__.py
@@ -11,24 +11,12 @@ Stats architecture:
 """
 import sys
 import argparse
-import logging
-import logging.handlers
 
 from circus.stats.streamer import StatsStreamer
+from circus.util import configure_logger
 from circus import logger
 from circus import util
 from circus import __version__
-
-
-LOG_LEVELS = {
-    "critical": logging.CRITICAL,
-    "error": logging.ERROR,
-    "warning": logging.WARNING,
-    "info": logging.INFO,
-    "debug": logging.DEBUG}
-
-LOG_FMT = r"%(asctime)s [%(process)d] [%(levelname)s] %(message)s"
-LOG_DATE_FMT = r"%Y-%m-%d %H:%M:%S"
 
 
 def main():
@@ -66,16 +54,7 @@ def main():
         sys.exit(0)
 
     # configure the logger
-    loglevel = LOG_LEVELS.get(args.loglevel.lower(), logging.INFO)
-    logger.setLevel(loglevel)
-    if args.logoutput == "-":
-        h = logging.StreamHandler()
-    else:
-        h = logging.handlers.WatchedFileHandler(args.logoutput)
-        util.close_on_exec(h.stream.fileno())
-    fmt = logging.Formatter(LOG_FMT, LOG_DATE_FMT)
-    h.setFormatter(fmt)
-    logger.addHandler(h)
+    configure_logger(logger, args.loglevel, args.logoutput)
 
     stats = StatsStreamer(args.endpoint, args.pubsub, args.statspoint,
                           args.ssh)

--- a/docs/source/for-ops/configuration.rst
+++ b/docs/source/for-ops/configuration.rst
@@ -109,7 +109,13 @@ circus - single section
     **loglevel**
         The loglevel that we want to see (default: INFO)
     **logoutput**
-        The logoutput file where we want to log (default: stdout)
+        The logoutput file where we want to log (default: ``-`` to log
+        on stdout). You can log to a remote syslog by using the
+        following syntax: ``syslog://host:port?facility`` where host
+        is your syslog server, port is optional and facility is the
+        syslog facility to use. If you wish to log to a local syslog
+        you can use ``syslog:///path/to/syslog/socket?facility``
+        instead.
 
 
 watcher:NAME - as many sections as you want


### PR DESCRIPTION
Add the possibility to configure the Python logging infrastructure to log in syslog instead in a file. Update circusd-stats to use the same configuration mechanism than circusd. As well when creating a watcher for circusd-stats, inherit the logging setting from the circusd configuration.

Unfortunately, there are no test for the configuration of logging and to be honest, I don't see how to test this.
