### PR TITLE
Append virtualenv bin to $PATH.

### DIFF
--- a/circus/util.py
+++ b/circus/util.py
@@ -742,6 +742,11 @@ def load_virtualenv(watcher):
 
     if not os.path.exists(sitedir):
         raise ValueError("%s does not exist" % sitedir)
+    
+    bindir = os.path.join(watcher.virtualenv, 'bin')
+    
+    if os.path.exists(bindir):
+        watcher.env['PATH'] = ':'.join([bindir,watcher.env.get('PATH','')])
 
     def process_pth(sitedir, name):
         packages = set()


### PR DESCRIPTION
We can using

```
[watcher:foo]
cmd=foo
virtualenv=virtualenv-path-of-foo
```

instead of 

```
[watcher:foo]
cmd=virtualenv-path-prog/bin/foo
virtualenv=virtualenv-path-of-foo
```
