### PR TITLE
Allow sending arbitrary signals to child procs via resource watcher

### DIFF
--- a/circus/plugins/resource_watcher.py
+++ b/circus/plugins/resource_watcher.py
@@ -1,5 +1,7 @@
+import signal
 import warnings
 from circus.plugins.statsd import BaseObserver
+from circus.util import to_bool
 
 
 class ResourceWatcher(BaseObserver):
@@ -29,9 +31,15 @@ class ResourceWatcher(BaseObserver):
         self.health_threshold = float(config.get("health_threshold",
                                       75))  # in %
         self.max_count = int(config.get("max_count", 3))
-        self._count_over_cpu = self._count_over_mem = 0
-        self._count_under_cpu = self._count_under_mem = 0
-        self._count_health = 0
+
+        self.process_children = to_bool(config.get("process_children", '0'))
+        self.child_signal = int(config.get("child_signal", signal.SIGTERM))
+
+        self._count_over_cpu = {}
+        self._count_over_mem = {}
+        self._count_under_cpu = {}
+        self._count_under_mem = {}
+        self._count_health = {}
 
     def look_after(self):
         info = self.call("stats", name=self.watcher)
@@ -40,6 +48,27 @@ class ResourceWatcher(BaseObserver):
             return
 
         stats = info['info']
+
+        max_cpu, max_mem, min_cpu, min_mem = self._collect_data(stats)
+        self._process_index('parent', max_cpu, max_mem, min_cpu, min_mem)
+        if not self.process_children:
+            return
+
+        for sub_info in stats.values():
+            if isinstance(sub_info, dict):
+                for child_info in sub_info['children']:
+                    max_cpu, max_mem, min_cpu, min_mem = self._collect_data({
+                        child_info['pid']: child_info
+                    })
+                    self._process_index(
+                        child_info['pid'],
+                        max_cpu,
+                        max_mem,
+                        min_cpu,
+                        min_mem
+                    )
+
+    def _collect_data(self, stats):
         cpus = []
         mems = []
 
@@ -59,50 +88,86 @@ class ResourceWatcher(BaseObserver):
             # we dont' have any process running. max = 0 then
             max_cpu = max_mem = min_cpu = min_mem = 0
 
+        return max_cpu, max_mem, min_cpu, min_mem
+
+    def _process_index(self, index, max_cpu, max_mem, min_cpu, min_mem):
+        if index not in self._count_over_cpu or \
+           index not in self._count_over_mem or \
+           index not in self._count_under_cpu or \
+           index not in self._count_under_mem or \
+           index not in self._count_health:
+            self._reset_index(index)
+
         if self.max_cpu and max_cpu > self.max_cpu:
             self.statsd.increment("_resource_watcher.%s.over_cpu" %
                                   self.watcher)
-            self._count_over_cpu += 1
+            self._count_over_cpu[index] += 1
         else:
-            self._count_over_cpu = 0
+            self._count_over_cpu[index] = 0
 
         if self.min_cpu is not None and min_cpu <= self.min_cpu:
             self.statsd.increment("_resource_watcher.%s.under_cpu" %
                                   self.watcher)
-            self._count_under_cpu += 1
+            self._count_under_cpu[index] += 1
         else:
-            self._count_under_cpu = 0
+            self._count_under_cpu[index] = 0
 
         if self.max_mem and max_mem > self.max_mem:
             self.statsd.increment("_resource_watcher.%s.over_memory" %
                                   self.watcher)
-            self._count_over_mem += 1
+            self._count_over_mem[index] += 1
         else:
-            self._count_over_mem = 0
+            self._count_over_mem[index] = 0
 
         if self.min_mem is not None and min_mem <= self.min_mem:
             self.statsd.increment("_resource_watcher.%s.under_memory" %
                                   self.watcher)
-            self._count_under_mem += 1
+            self._count_under_mem[index] += 1
         else:
-            self._count_under_mem = 0
+            self._count_under_mem[index] = 0
 
         if self.health_threshold and \
                 (max_cpu + max_mem) / 2.0 > self.health_threshold:
             self.statsd.increment("_resource_watcher.%s.over_health" %
                                   self.watcher)
-            self._count_health += 1
+            self._count_health[index] += 1
         else:
-            self._count_health = 0
+            self._count_health[index] = 0
 
-        if max([self._count_over_cpu, self._count_under_cpu,
-                self._count_over_mem, self._count_under_mem,
-                self._count_health]) > self.max_count:
+        if max([self._count_over_cpu[index], self._count_under_cpu[index],
+                self._count_over_mem[index], self._count_under_mem[index],
+                self._count_health[index]]) > self.max_count:
             self.statsd.increment("_resource_watcher.%s.restarting" %
                                   self.watcher)
+
             # todo: restart only process instead of the whole watcher
-            self.cast("restart", name=self.watcher)
-            self._count_mem = self._count_health = self._count_mem = 0
+            if index == 'parent':
+                self.cast("restart", name=self.watcher)
+                self._reset_index(index)
+            else:
+                self.cast(
+                    "signal",
+                    name=self.watcher,
+                    signum=self.child_signal,
+                    child_pid=index
+                )
+                self._remove_index(index)
+
+            self._reset_index(index)
+
+    def _reset_index(self, index):
+        self._count_over_cpu[index] = 0
+        self._count_over_mem[index] = 0
+        self._count_under_cpu[index] = 0
+        self._count_under_mem[index] = 0
+        self._count_health[index] = 0
+
+    def _remove_index(self, index):
+        del self._count_over_cpu[index]
+        del self._count_over_mem[index]
+        del self._count_under_cpu[index]
+        del self._count_under_mem[index]
+        del self._count_health[index]
 
     def stop(self):
         self.statsd.stop()


### PR DESCRIPTION
Previously it was impossible to monitor the resource consumption of child processes. This doesn't affect cases where one mind bind to a file descriptor like Chausette and therefore use multiple top-level processes. However, there are cases where you might run processes under gunicorn - or similar - and have the master process sending off to the application that handles the request. In these cases, the master process will not feature the resource usage you might otherwise see.

You can now define the following config variables in the `resource_watcher` config:
- `process_children`: (boolean default False) Whether or not to also process child processes in determining min/max resource usage
- `child_signal`: (int default signal.SIGTERM) An integer mapping to a signal in the POSIX standard. Note that this may change from system to system re: the python implementation of the signal library.

In all cases, the original implementation of grouping master processes together stays the same. When `process_children` is set to True, each child process has it's resource consumption aggregated. If the resource consumption is higher than that defined by the resource_watcher config, then the signal specified in `child_signal` is sent to the process.

This commit also fixes the issue where not all counters were properly reset after restarting a watcher.

Refs #756
