### PR TITLE
ZMQVersionError: disconnect requires libzmq >= 3.2, have 2.2.0

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -2,7 +2,7 @@
 ## To use buildout you need some c-headerfiles.
 ## Simply call:
 ##
-## $: sudo apt-get install build-essential libzmq-dev python-dev
+## $: sudo apt-get install build-essential libzmq3-dev python-dev
 ## $: python bootstrap.py
 ## $: bin/buildout
 ##

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Roman Imankulov <roman.imankulov@gmail.com>
 DM-Upload-Allowed: yes
 Build-Depends: debhelper (>= 7),
-               libzmq-dev (>= 2.1.9),
+               libzmq3-dev (>= 3.2.0),
                python | python-all | python-dev | python-all-dev (>=2.6.3),
                python-setuptools,
                python-zmq (>= 2.1.9),

--- a/docs/source/tutorial/step-by-step.rst
+++ b/docs/source/tutorial/step-by-step.rst
@@ -19,7 +19,7 @@ Circus is tested on Mac OS X and Linux with the latest Python 2.6, 2.7,
 
 On Debian-based systems::
 
-    $ sudo apt-get install libzmq-dev libevent-dev python-dev python-virtualenv
+    $ sudo apt-get install libzmq3-dev libevent-dev python-dev python-virtualenv
 
 Create a virtualenv and install *circus*, *circus-web* and *chaussette*
 in it ::


### PR DESCRIPTION
I had to install libzmq3-dev on Ubuntu before installing circus to get this fixed.
