### PR TITLE
Optimize Watcher.kill_process

### DIFF
--- a/circus/watcher.py
+++ b/circus/watcher.py
@@ -673,10 +673,10 @@ class Watcher(object):
         process.stopping = True
         waited = 0
         while waited < self.graceful_timeout:
-            yield tornado_sleep(1)
-            waited += 1
             if not process.is_alive():
                 break
+            yield tornado_sleep(0.1)
+            waited += 0.1
         if waited >= self.graceful_timeout:
             # We are not smart anymore
             self.send_signal_process(process, signal.SIGKILL)


### PR DESCRIPTION
`Watcher.kill_process` was always waiting 1s for each process. Now it only waits if it's necessary, and it waits for 0.1s instead of 1s.

On my machine, it reduces the time spent by the tests from **105s** to **42s** !
