### PR TITLE
The upstart configuration is failing to start circus

### DIFF
--- a/debian/circus.upstart
+++ b/debian/circus.upstart
@@ -1,7 +1,7 @@
 description "circusd"
 
 start on filesystem and net-device-up IFACE=lo
-stop on runlevel [016]
+stop on shutdown
 
 respawn
 exec /usr/bin/circusd /etc/circus/circusd.ini


### PR DESCRIPTION
The process gets SIGINT every time, respawns and dies after too many respawns that are done one after another.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/circus-tent/circus/786)
<!-- Reviewable:end -->
