### PR TITLE
[NOT READY] Add six to test requirements.

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,3 +7,4 @@ nose-cov==1.6
 coverage==3.7
 randomize==0.9
 PyYAML==3.10
+six==1.6.1


### PR DESCRIPTION
Previously, this was only implicitly installed through another dependency, but it is directly required in test_circusd.
