### PR TITLE
Move configuration file to a variable for ease of customization.

### DIFF
--- a/debian/circus.init
+++ b/debian/circus.init
@@ -16,7 +16,8 @@ DESC="circus daemon"
 NAME=circusd
 DAEMON=/usr/bin/circusd
 PIDFILE=/var/run/$NAME.pid
-DAEMON_ARGS="--daemon --pidfile $PIDFILE /etc/circus/circusd.ini"
+CONFIG=/etc/circus/circusd.ini
+DAEMON_ARGS="--daemon --pidfile $PIDFILE $CONFIG"
 SCRIPTNAME=/etc/init.d/$NAME
 
 # Exit if the package is not installed


### PR DESCRIPTION
Micro Debian init file abstraction improvement that moves the configuration file into a variable so customizations of the file are a bit easier when the configuration file lives elsewhere.
