### PR TITLE
Fix file descriptor inheritance problem with python3.4 (#787)

### DIFF
--- a/circus/sockets.py
+++ b/circus/sockets.py
@@ -70,6 +70,11 @@ class CircusSocket(socket.socket):
 
         self.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 
+        # Since python 3.4, file descriptors inheritance for children processes
+        #  is not the default anymore (#787)
+        if hasattr(self, 'set_inheritable'):
+            self.set_inheritable(True)
+
     @property
     def location(self):
         if self.is_unix:

--- a/circus/tests/test_sockets.py
+++ b/circus/tests/test_sockets.py
@@ -193,5 +193,16 @@ class TestSockets(TestCase):
                 socket.SO_REUSEPORT = saved
             sock.close()
 
+    @skipIf(not hasattr(os, 'set_inheritable'),
+            'os.set_inheritable unsupported')
+    def test_set_inheritable(self):
+        sockfile = self._get_tmp_filename()
+        sock = CircusSocket('somename', path=sockfile, umask=0)
+        try:
+            sock.bind_and_listen()
+            self.assertTrue(sock.get_inheritable())
+        finally:
+            sock.close()
+
 
 test_suite = EasyTestSuite(__name__)


### PR DESCRIPTION
Proposed fix for #787.

The added unit test will be skipped for python < 3.4.

Tox isn't configured for py34 yet, and adding it fails because of #768.
