### PR TITLE
Set minimum pyzmq version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ if not hasattr(sys, 'version_info') or sys.version_info < (2, 6, 0, 'final'):
     raise SystemExit("Circus requires Python 2.6 or higher.")
 
 
-install_requires = ['iowait', 'psutil', 'pyzmq', 'tornado>=3.0']
+install_requires = ['iowait', 'psutil', 'pyzmq>=13.1.0', 'tornado>=3.0']
 
 try:
     import argparse     # NOQA


### PR DESCRIPTION
In addition of https://github.com/mozilla-services/circus/pull/647, we should set the minimum pyzmq version in setup.py.
