### PR TITLE
Require tornado < 4.0 (compatibility breaking changes in major release)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ if not hasattr(sys, 'version_info') or sys.version_info < (2, 6, 0, 'final'):
     raise SystemExit("Circus requires Python 2.6 or higher.")
 
 
-install_requires = ['iowait', 'psutil', 'pyzmq>=13.1.0', 'tornado>=3.0']
+install_requires = ['iowait', 'psutil', 'pyzmq>=13.1.0', 'tornado>=3.0,<4.0']
 
 try:
     import argparse     # NOQA


### PR DESCRIPTION
Tornado 4.0 was recently released and is the default version on PyPI. There are backwards-incompatible changes that break tests and possibly worse in the core codebase. Ensure tornado < 4.0 in setup.py for now.
