### PR TITLE
New circus command "rmprocess" and updated "incr" command

### DIFF
--- a/circus/commands/__init__.py
+++ b/circus/commands/__init__.py
@@ -17,6 +17,7 @@ from circus.commands import (   # NOQA
     reloadconfig,
     restart,
     rmwatcher,
+    rmprocess,
     sendsignal,
     set,
     start,

--- a/circus/commands/incrproc.py
+++ b/circus/commands/incrproc.py
@@ -60,12 +60,12 @@ class IncrProc(Command):
     def execute(self, arbiter, props):
         watcher = self._get_watcher(arbiter, props.get('name'))
         if watcher.singleton:
-            return {"numprocesses": watcher.numprocesses, "singleton": True}
+            return {"numprocesses": watcher.numprocesses, "singleton": True, 'pids': []}
         else:
             nb = props.get("nb", 1)
             resp = TransformableFuture()
             resp.set_upstream_future(watcher.incr(nb))
-            resp.set_transform_function(lambda x: {"numprocesses": x})
+            resp.set_transform_function(lambda x: x)
             return resp
 
     def console_msg(self, msg):

--- a/circus/commands/incrproc.py
+++ b/circus/commands/incrproc.py
@@ -60,7 +60,11 @@ class IncrProc(Command):
     def execute(self, arbiter, props):
         watcher = self._get_watcher(arbiter, props.get('name'))
         if watcher.singleton:
-            return {"numprocesses": watcher.numprocesses, "singleton": True, 'pids': []}
+            return {
+                "numprocesses": watcher.numprocesses,
+                "singleton": True,
+                "pids": []
+            }
         else:
             nb = props.get("nb", 1)
             resp = TransformableFuture()

--- a/circus/commands/rmprocess.py
+++ b/circus/commands/rmprocess.py
@@ -1,0 +1,75 @@
+from circus.commands.base import Command
+from circus.exc import ArgumentError
+from circus.util import TransformableFuture
+
+
+class RmProcess(Command):
+    """\
+        Remove processes in a watcher
+        ==============================================
+
+        This comment removes processes in a watcher.
+
+        ZMQ Message
+        -----------
+
+        ::
+
+            {
+                "command": "rmprocess",
+                "properties": {
+                    "name": "<watchername>",
+                    "pids": <pids>
+                }
+            }
+
+        The response return the number of removed processes in the 'nr`
+        property::
+
+            { "status": "ok", "nr": <n>, "time", "timestamp" }
+
+        Command line
+        ------------
+
+        ::
+
+            $ circusctl rmprocess <name> <pids>
+
+        Options
+        +++++++
+
+        - <name>: name of the watcher.
+        - <pids>: list of pids to remove
+
+    """
+
+    name = "rmprocess"
+    properties = ['name', 'pids']
+    options = Command.waiting_options
+
+    def message(self, *args, **opts):
+        largs = len(args)
+        if largs != 2:
+            raise ArgumentError("Invalid number of arguments")
+
+        props = {
+            'name': args[0],
+            'pids': args[1],
+        }
+        return self.make_message(**props)
+
+    def execute(self, arbiter, props):
+        watcher = self._get_watcher(arbiter, props.get('name'))
+        if watcher.singleton:
+            return {"numprocesses": watcher.numprocesses, "singleton": True, 'pids': []}
+        else:
+            #resp = TransformableFuture()
+            #resp.set_upstream_future(watcher.rm_processes(props['pids']))
+            #resp.set_transform_function(lambda x: {'resultom':x})
+            _r = watcher.rm_processes(props['pids'])
+            return _r
+
+    def console_msg(self, msg):
+        if msg.get("status") == "ok":
+            return str(msg.get("nr", "ok"))
+        return self.console_error(msg)

--- a/circus/commands/rmprocess.py
+++ b/circus/commands/rmprocess.py
@@ -1,6 +1,5 @@
 from circus.commands.base import Command
 from circus.exc import ArgumentError
-from circus.util import TransformableFuture
 
 
 class RmProcess(Command):


### PR DESCRIPTION
"rmprocess" is used to remove processes from a given watcher. I had to remove some processes from a watcher and "decr" was not suitable for me because it removes the oldest processes. With the new command you can pass the list of pids to be removed.
"incr" command is updated to include the new pids in the response.