### PR TITLE
Add example YAML for loggerconfig option

### DIFF
--- a/docs/source/for-ops/configuration.rst
+++ b/docs/source/for-ops/configuration.rst
@@ -125,7 +125,6 @@ circus - single section
 		
 	.. code-block:: yaml
 	
-	        ---
 	        version: 1
 	        disable_existing_loggers: false
 	        formatters:


### PR DESCRIPTION
It's really difficult to find documentation on what needs to be in the optional ini, yaml, or json files.
This snippet comes out of the test case from the source code.

It should, at least, give people a place to start when using this option.
