### PR TITLE
Parallel circusctl watcher restarts using wildcards

### DIFF
--- a/circus/arbiter.py
+++ b/circus/arbiter.py
@@ -727,40 +727,50 @@ class Arbiter(object):
 
     @synchronized("arbiter_start_watchers")
     @gen.coroutine
-    def start_watchers(self):
-        yield self._start_watchers()
+    def start_watchers(self, watcher_iter_func=None):
+        yield self._start_watchers(watcher_iter_func=watcher_iter_func)
 
     @gen.coroutine
-    def _start_watchers(self):
-        for watcher in self.iter_watchers():
+    def _start_watchers(self, watcher_iter_func=None):
+        if watcher_iter_func is None:
+            watchers = self.iter_watchers()
+        else:
+            watchers = watcher_iter_func()
+        for watcher in watchers:
             if watcher.autostart:
                 yield watcher._start()
                 yield tornado_sleep(self.warmup_delay)
 
     @gen.coroutine
     @debuglog
-    def _stop_watchers(self, close_output_streams=False):
+    def _stop_watchers(self, close_output_streams=False,
+                       watcher_iter_func=None):
+        if watcher_iter_func is None:
+            watchers = self.iter_watchers(reverse=False)
+        else:
+            watchers = watcher_iter_func(reverse=False)
         yield [w._stop(close_output_streams)
-               for w in self.iter_watchers(reverse=False)]
+               for w in watchers]
 
     @synchronized("arbiter_stop_watchers")
     @gen.coroutine
-    def stop_watchers(self):
-        yield self._stop_watchers()
+    def stop_watchers(self, watcher_iter_func=None):
+        yield self._stop_watchers(watcher_iter_func=watcher_iter_func)
 
     @gen.coroutine
-    def _restart(self, inside_circusd=False):
+    def _restart(self, inside_circusd=False, watcher_iter_func=None):
         if inside_circusd:
             self._restarting = True
             yield self._stop()
         else:
-            yield self._stop_watchers()
-            yield self._start_watchers()
+            yield self._stop_watchers(watcher_iter_func=watcher_iter_func)
+            yield self._start_watchers(watcher_iter_func=watcher_iter_func)
 
     @synchronized("arbiter_restart")
     @gen.coroutine
-    def restart(self, inside_circusd=False):
-        yield self._restart(inside_circusd=inside_circusd)
+    def restart(self, inside_circusd=False, watcher_iter_func=None):
+        yield self._restart(inside_circusd=inside_circusd,
+                            watcher_iter_func=watcher_iter_func)
 
     @property
     def endpoint_owner_mode(self):

--- a/circus/commands/start.py
+++ b/circus/commands/start.py
@@ -1,6 +1,6 @@
 from circus.commands.base import Command
+from circus.commands.restart import execute_watcher_start_stop_restart
 from circus.exc import ArgumentError
-from circus.util import TransformableFuture
 
 
 class Start(Command):
@@ -46,7 +46,7 @@ class Start(Command):
         Options
         +++++++
 
-        - <name>: name of the watcher
+        - <name>: (wildcard) name of the watcher(s)
 
     """
     name = "start"
@@ -62,13 +62,6 @@ class Start(Command):
         return self.make_message(**opts)
 
     def execute(self, arbiter, props):
-        if 'name' in props:
-            watcher = self._get_watcher(arbiter, props['name'])
-            if props.get('waiting'):
-                resp = TransformableFuture()
-                resp.set_upstream_future(watcher.start())
-                resp.set_transform_function(lambda x: {"info": x})
-                return resp
-            return watcher.start()
-        else:
-            return arbiter.start_watchers()
+        return execute_watcher_start_stop_restart(
+            arbiter, props, 'start', arbiter.start_watchers,
+            arbiter.start_watchers)

--- a/circus/commands/stop.py
+++ b/circus/commands/stop.py
@@ -1,4 +1,5 @@
 from circus.commands.base import Command
+from circus.commands.restart import execute_watcher_start_stop_restart
 
 
 class Stop(Command):
@@ -46,7 +47,7 @@ class Stop(Command):
         Options
         +++++++
 
-        - <name>: name of the watcher
+        - <name>: (wildcard) name of the watcher(s)
     """
 
     name = "stop"
@@ -58,8 +59,6 @@ class Stop(Command):
         return self.make_message(**opts)
 
     def execute(self, arbiter, props):
-        if 'name' in props:
-            watcher = self._get_watcher(arbiter, props['name'])
-            return watcher.stop()
-        else:
-            return arbiter.stop_watchers()
+        return execute_watcher_start_stop_restart(
+            arbiter, props, 'stop', arbiter.stop_watchers,
+            arbiter.stop_watchers)


### PR DESCRIPTION
This pull requests references #814 and somehow #776.

Since our projects are growing we really need the posibility to group watchers together. We found the solution using wildcards the easiest for now.

The best solution for us would be for eg. a tagging system where we can restart watchers by tag.

However, this pull request is quiet dirty. Someone who is more handy with circus and tornado have to decide what to do with it.
We are really looking forward to get such a functionality in the main branch.