### PR TITLE
Add pyyaml as a requirement.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ if not hasattr(sys, 'version_info') or sys.version_info < (2, 6, 0, 'final'):
     raise SystemExit("Circus requires Python 2.6 or higher.")
 
 
-install_requires = ['iowait', 'psutil', 'pyzmq>=13.1.0', 'tornado>=3.0,<4.0']
+install_requires = ['iowait', 'psutil', 'pyzmq>=13.1.0', 'tornado>=3.0,<4.0', 'pyyaml']
 
 try:
     import argparse     # NOQA


### PR DESCRIPTION
The ability to use YAML files for logger configuration requires this module.
Not including it causes confusion for people trying to use that new functionality.

Cheers!
Mike
