### PR TITLE
Add start callback

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -88,3 +88,4 @@ List of contributors:
 - Sylvain Viollon <sviollon@minddistrict.com>
 - James Ascroft-Leigh <jwal@jwal.me.uk>
 - Mike Dunn <mike@eikonomega.com>
+- Yannick PEROUX <yannick.peroux@gmail.com>

--- a/circus/arbiter.py
+++ b/circus/arbiter.py
@@ -496,7 +496,7 @@ class Arbiter(object):
 
     @gen.coroutine
     @debuglog
-    def start(self):
+    def start(self, cb=None):
         """Starts all the watchers.
 
         If the ioloop has been provided during __init__() call,
@@ -506,6 +506,10 @@ class Arbiter(object):
         starts all watchers and the eventloop (and blocks here). In this mode
         the method MUST NOT yield anything because it's called as a standard
         method.
+
+        :param cb: Callback called after all the watchers have been started,
+                   when the loop hasn't been provided.
+        :type function:
         """
         logger.info("Starting master on pid %s", self.pid)
         self.initialize()
@@ -520,7 +524,9 @@ class Arbiter(object):
                 yield self.start_watchers()
             else:
                 # start_watchers will be called just after the start_io_loop()
-                self.loop.add_future(self.start_watchers(), lambda x: None)
+                if not cb:
+                    cb = lambda x: None
+                self.loop.add_future(self.start_watchers(), cb)
             logger.info('Arbiter now waiting for commands')
             self._running = True
             if not self._provided_loop:

--- a/circus/tests/test_arbiter.py
+++ b/circus/tests/test_arbiter.py
@@ -10,7 +10,6 @@ try:
     from urllib.parse import urlparse
 except ImportError:
     from urlparse import urlparse  # NOQA
-from tornado import gen
 
 from circus.arbiter import Arbiter
 from circus.client import CircusClient

--- a/circus/tests/test_arbiter.py
+++ b/circus/tests/test_arbiter.py
@@ -588,7 +588,6 @@ class TestArbiter(TestCircus):
     Unit tests for the arbiter class to codify requirements within
     behavior.
     """
-    @tornado.testing.gen_test
     def test_start_with_callback(self):
         controller = "tcp://127.0.0.1:%d" % get_available_port()
         sub = "tcp://127.0.0.1:%d" % get_available_port()
@@ -598,12 +597,9 @@ class TestArbiter(TestCircus):
 
         def callback(*args):
             callee()
-            arbiter.loop.stop()
+            arbiter.stop()
 
-        try:
-            yield arbiter.start(cb=callback)
-        finally:
-            yield arbiter.stop()
+        arbiter.start(cb=callback)
 
         self.assertEqual(callee.call_count, 1)
 


### PR DESCRIPTION
This 'cb' argument corresponds to a callback which will be called after the watchers have been started, if no loop has been provided.

It is called 'cb' and not 'callback' as otherwise it would conflict with the 'callback' argument accepted by every coroutines. Note that we can't use this argument here as arbiter.start will not return until the end, so the callback would never be called.

This is really helpful for projects using Circus as a library and not wanting to use a custom loop, as it allows them to call a coroutine inside the loop after everything has been initialized.

Providing a custom loop for Circus can be very hard, as you have to rewrite a lot of code to handle the shutdown properly. For example you have to write your own sighandlers. With this argument, most projects don't need to use their own loop.

It doesn't change anything for projects not using Circus as a library or using their own loop.

Note that I didn't add a test as it's nearly impossible to add one. In the tests we provide a custom loop so the callback will not be called.
