### PR TITLE
Reloading hook modules in arbiter.reload_from_config function

### DIFF
--- a/circus/arbiter.py
+++ b/circus/arbiter.py
@@ -346,7 +346,7 @@ class Arbiter(object):
         if added_sn or deleted_sn:
             # make sure all existing watchers get the new sockets in
             # their attributes and get the old removed
-            # XXX: is this necessary? self.sockets is an mutable
+            # XXX: is this necessary? self.sockets is a mutable
             # object
             for watcher in self.iter_watchers():
                 # XXX: What happens as initalize is called on a
@@ -399,6 +399,9 @@ class Arbiter(object):
                 changed_wn.add(n)
                 deleted_wn.add(n)
                 added_wn.add(n)
+            else:
+                # reload hooks of unchanged watcher
+                w.reload_hooks()
 
         # delete watchers
         for n in deleted_wn:
@@ -417,6 +420,9 @@ class Arbiter(object):
             yield self.start_watcher(w)
             self.watchers.append(w)
             self._watchers_names[w.name.lower()] = w
+            # when the watcher was changed reload it's hooks
+            if n in changed_wn:
+                w.reload_hooks()
 
     @classmethod
     def load_from_config(cls, config_file, loop=None):

--- a/circus/watcher.py
+++ b/circus/watcher.py
@@ -388,6 +388,11 @@ class Watcher(object):
         for name, (callable_or_name, ignore_failure) in hooks.items():
             self._resolve_hook(name, callable_or_name, ignore_failure)
 
+    def reload_hooks(self, ignore_failure=False):
+        for hook_name, func in self.hooks.items():
+            hook = func.__module__ + ':' + func.__name__
+            self._resolve_hook(hook_name, hook, ignore_failure, reload_module=True)
+
     @property
     def pending_socket_event(self):
         return self.on_demand and not self.arbiter.socket_event


### PR DESCRIPTION
Hooks were only reloaded when the full circus daemon were restarted. Now all hooks are reloaded when for eg. reloadconfig is called.

I think I implemented it a little bit dirty. As you can see in watcher.py:393 I'm rebuilding the hook string and call _resolve_hook again, but I think this should work in the most cases.
The much better way would be to store the original hook string in an extra dict next to self.hooks or get the strings from the config.
