### PR TITLE
Allow virtualenv and virtualenv_py_ver options in add command.

### DIFF
--- a/circus/commands/util.py
+++ b/circus/commands/util.py
@@ -92,7 +92,7 @@ def validate_option(key, val):
                   'shell', 'env', 'cmd', 'args', 'copy_env', 'retry_in',
                   'max_retry', 'graceful_timeout', 'stdout_stream',
                   'stderr_stream', 'max_age', 'max_age_variance', 'respawn',
-                  'singleton', 'hooks')
+                  'singleton', 'hooks', 'virtualenv', 'virtualenv_py_ver')
 
     valid_prefixes = ('stdout_stream.', 'stderr_stream.', 'hooks.', 'rlimit_')
 

--- a/circus/watcher.py
+++ b/circus/watcher.py
@@ -178,6 +178,10 @@ class Watcher(object):
     - **virtualenv** -- The root directory of a virtualenv. If provided, the
       watcher will load the environment for its execution. (default: None)
 
+    - **virtualenv_py_ver** -- Python version that is installed in virtualenv.
+      Use it to change default circus behaviour when it tries to load same version as
+      circus is using.
+
     - **close_child_stdout**: If True, closes the stdout after the fork.
       default: False.
 


### PR DESCRIPTION
Hello,

i was trying to add watcher using ZMQ and `add` command. When I specified `virtualenv` option i got error that this option is not allowed which is not true because it exist in `watcher` constructor. 

I have created small PR that allows such options, also documents `virtualenv_py_ver` watcher constructor option.

Please consider to merge this. Thank you in advance. 
