### PR TITLE
respawn option name added to optnames.

### DIFF
--- a/circus/watcher.py
+++ b/circus/watcher.py
@@ -254,7 +254,7 @@ class Watcher(object):
                 # such as SystemRoot
                 self.copy_env = True
 
-        self.optnames = (("numprocesses", "warmup_delay", "working_dir",
+        self.optnames = (("respawn", "numprocesses", "warmup_delay", "working_dir",
                           "uid", "gid", "send_hup", "stop_signal",
                           "stop_children", "shell", "shell_args",
                           "env", "max_retry", "cmd", "args",


### PR DESCRIPTION
Hello,

i was writting plugin which needed to check whether watcher has set `respawn` option. I couldn't do it because `respawn` option was missing in `watcher.optnames` and `get` command validates `keys` according to list of `optnames`.

Here I send simple PR which allows to get `respawn` option value using `get` command from plugin API.

Please consider merging this PR as other users may have same problem.

Thank you! 