### PR TITLE
Fix #804, don't pass argv sequence to Popen with shell=True.

### DIFF
--- a/circus/tests/test_pidfile.py
+++ b/circus/tests/test_pidfile.py
@@ -1,16 +1,14 @@
 import tempfile
 import os
-import shlex
 import subprocess
 
 from circus.pidfile import Pidfile
-from circus.tests.support import TestCase, EasyTestSuite, SLEEP, IS_WINDOWS
+from circus.tests.support import TestCase, EasyTestSuite, SLEEP
 
 
 class TestPidfile(TestCase):
     def test_pidfile(self):
-        cmd = shlex.split(SLEEP % 120, posix=not IS_WINDOWS)
-        proc = subprocess.Popen(cmd, shell=True)
+        proc = subprocess.Popen(SLEEP % 120, shell=True)
         fd, path = tempfile.mkstemp()
         os.close(fd)
 


### PR DESCRIPTION
From Popen's documentation.
> The shell argument (which defaults to False) specifies whether to use the shell as the program to execute. If shell is True, it is recommended to pass args as a string rather than as a sequence.

This caused the python shell to be spawned during the tests.
