### PR TITLE
Close the output streams if all watcher processes are stopping

### DIFF
--- a/circus/tests/test_papa_stream.py
+++ b/circus/tests/test_papa_stream.py
@@ -37,7 +37,7 @@ class TestPapaStream(TestCircus):
         super(TestPapaStream, self).setUp()
         papa.set_debug_mode(quit_when_connection_closed=True)
         papa.set_default_port(self.papa_port)
-        # papa.set_default_connection_timeout(120)
+        papa.set_default_connection_timeout(120)
         fd, self.stdout = tempfile.mkstemp()
         os.close(fd)
         fd, self.stderr = tempfile.mkstemp()

--- a/circus/watcher.py
+++ b/circus/watcher.py
@@ -9,6 +9,7 @@ from random import randint
 try:
     from itertools import zip_longest as izip_longest
 except ImportError:
+    # noinspection PyUnresolvedReferences
     from itertools import izip_longest  # NOQA
 import site
 from tornado import gen
@@ -813,7 +814,8 @@ class Watcher(object):
     @util.synchronized("watcher_stop")
     @gen.coroutine
     def stop(self):
-        yield self._stop()
+        # stop streams too since we are stopping the watcher completely
+        yield self._stop(True)
 
     @util.debuglog
     @gen.coroutine
@@ -935,7 +937,8 @@ class Watcher(object):
         # probably prevented startup so give up
         if not self.processes or not self.call_hook('after_start'):
             logger.debug('Aborting startup')
-            yield self._stop()
+            # stop streams too since we are bailing on this watcher completely
+            yield self._stop(True)
             return
 
         self._status = "active"


### PR DESCRIPTION
This change will close the redirected streams on watcher.stop() and if the after_start hook indicates that we should abort startup. Should address issue reported by @bengecko in #884.