### PR TITLE
Send signal with 'recursive=True' really recursive

### DIFF
--- a/circus/commands/sendsignal.py
+++ b/circus/commands/sendsignal.py
@@ -140,7 +140,7 @@ class Signal(Command):
 
                 if recursive:
                     # also send to the children
-                    watcher.send_signal_children(pid, signum)
+                    watcher.send_signal_children(pid, signum, recursive=True)
 
     def validate(self, props):
         super(Signal, self).validate(props)

--- a/circus/process.py
+++ b/circus/process.py
@@ -531,9 +531,9 @@ class Process(object):
             raise NoSuchProcess(pid)
 
     @debuglog
-    def send_signal_children(self, signum):
+    def send_signal_children(self, signum, recursive=False):
         """Send signal *signum* to all children."""
-        for child in get_children(self._worker):
+        for child in get_children(self._worker, recursive):
             try:
                 child.send_signal(signum)
             except OSError as e:

--- a/circus/tests/test_command_signal.py
+++ b/circus/tests/test_command_signal.py
@@ -72,7 +72,6 @@ def read_from_stream(stream, desired_channel, timeout=5):
     while not channels[desired_channel] and time.time() - start < timeout:
         try:
             data = stream.get_nowait()
-            print data
             data = s(data['data']).split('\n')
             accumulator += data.pop(0)
             if data:

--- a/circus/tests/test_command_signal.py
+++ b/circus/tests/test_command_signal.py
@@ -16,7 +16,7 @@ exiting = False
 channels = {0: [], 1: [], 2: [], 3: []}
 
 
-def run_process(child_id, test_file=None):
+def run_process(child_id, test_file=None, recursive=False, num_children=3):
     def send(msg):
         sys.stdout.write('{0}:{1}\n'.format(child_id, msg))
         sys.stdout.flush()
@@ -28,9 +28,16 @@ def run_process(child_id, test_file=None):
 
     if not isinstance(child_id, int):
         child_id = 0
-        for i in range(3):
-            p = multiprocessing.Process(target=run_process, args=(i + 1,))
-            p.daemon = True
+    if child_id == 0 or (recursive and child_id < 2):
+        # create children for top level process
+        # or first two second level processes
+        for i in range(num_children):
+            new_child_id = child_id * 10 + i + 1
+            p = multiprocessing.Process(
+                target=run_process,
+                args=(new_child_id,),
+                kwargs={'recursive': recursive, 'num_children': num_children})
+            p.daemon = not (recursive and new_child_id < 2)
             p.start()
             children.append(p)
 
@@ -52,13 +59,20 @@ def run_process(child_id, test_file=None):
     send('EXITING')
 
 
+def run_process_recursive(child_id):
+    run_process(child_id, recursive=True, num_children=2)
+
+
 @tornado.gen.coroutine
 def read_from_stream(stream, desired_channel, timeout=5):
     start = time.time()
     accumulator = ''
+    if desired_channel not in channels:
+        channels[desired_channel] = []
     while not channels[desired_channel] and time.time() - start < timeout:
         try:
             data = stream.get_nowait()
+            print data
             data = s(data['data']).split('\n')
             accumulator += data.pop(0)
             if data:
@@ -156,6 +170,74 @@ class SignalCommandTest(TestCircus):
         self.assertEqual(res, 'TERM')
         res = yield read_from_stream(stream, 3)
         self.assertEqual(res, 'EXITING')
+
+        timeout = time.time() + 5
+        stopped = False
+        while time.time() < timeout:
+            res = yield client.send_message('status', name='test')
+            if res['status'] == 'stopped':
+                stopped = True
+                break
+            self.assertEqual(res['status'], 'stopping')
+        self.assertTrue(stopped)
+
+        yield self.stop_arbiter()
+
+
+class SignalRecursiveCommandTest(TestCircus):
+
+    @skipIf(IS_WINDOWS, "Streams not supported")
+    @tornado.testing.gen_test
+    def test_handler(self):
+        stream = QueueStream()
+        cmd = 'circus.tests.test_command_signal.run_process_recursive'
+        stdout_stream = {'stream': stream}
+        stderr_stream = {'stream': stream}
+        yield self.start_arbiter(cmd=cmd, stdout_stream=stdout_stream,
+                                 stderr_stream=stderr_stream, stats=True,
+                                 stop_signal=signal.SIGINT,
+                                 debug=False)
+
+        def assert_read(channel, *values):
+            for value in values:
+                data = yield read_from_stream(stream, channel)
+                self.assertEqual(data, value)
+
+        # waiting for all processes to start
+        for c in (0, 1, 2, 11, 12):
+            assert_read(c, 'STARTED')
+
+        # checking that our system is live and running
+        client = AsyncCircusClient(endpoint=self.arbiter.endpoint)
+        res = yield client.send_message('list')
+        watchers = sorted(res['watchers'])
+        self.assertEqual(['circusd-stats', 'test'], watchers)
+
+        # send USR1 to parent only
+        res = yield client.send_message('signal', name='test', signum='usr1')
+        self.assertEqual(res['status'], 'ok')
+        assert_read(0, 'USR1')
+
+        # send USR2 to children only
+        res = yield client.send_message('signal', name='test', signum='usr2',
+                                        children=True)
+        self.assertEqual(res['status'], 'ok')
+        for c in (1, 2):
+            assert_read(c, 'USR2')
+
+        # send HUP to parent and children
+        res = yield client.send_message('signal', name='test', signum='hup',
+                                        recursive=True)
+        self.assertEqual(res['status'], 'ok')
+        for c in (0, 1, 2, 11, 12):
+            assert_read(c, 'HUP')
+
+        # stop process
+        res = yield client.send_message('stop', name='test')
+        self.assertEqual(res['status'], 'ok')
+        assert_read(0, 'INT', 'EXITING')
+        for c in (1, 2, 11, 12):
+            assert_read(c, 'TERM', 'EXITING')
 
         timeout = time.time() + 5
         stopped = False

--- a/circus/watcher.py
+++ b/circus/watcher.py
@@ -779,11 +779,11 @@ class Watcher(object):
                 raise
 
     @util.debuglog
-    def send_signal_children(self, pid, signum):
+    def send_signal_children(self, pid, signum, recursive=False):
         """Send signal to all children.
         """
         process = self.processes[int(pid)]
-        process.send_signal_children(signum)
+        process.send_signal_children(signum, recursive)
 
     @util.debuglog
     def status(self):


### PR DESCRIPTION
This addresses #880. When the parameter `recursive` is True, the signal is send to all descendants of the process and not just to its children.