### PR TITLE
enable automated deploy to pypi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,9 @@ notifications:
     on_success: change
 after_success:
   - .coveralls.sh
+deploy:
+  provider: pypi
+  user: "FOO"
+  password: "BAR"
+  on:
+    tags: true


### PR DESCRIPTION
As states on http://docs.travis-ci.com/user/deployment/pypi/ - you just need to fill username and encrypted password. Then, travis will push to Pypi new version of Chaussette on each tagged commit.

This exactly same PR as https://github.com/circus-tent/chaussette/pull/71, created after suggestion of @k4nar :)