### PR TITLE
READY FOR REVIEW - Fix inconsistency between configuration and hooks docs regarding priority setting

### DIFF
--- a/docs/source/for-devs/writing-hooks.rst
+++ b/docs/source/for-devs/writing-hooks.rst
@@ -31,7 +31,7 @@ events.  Available hooks are:
   the hook returns **False** the signal is not sent (except SIGKILL which is
   always sent)
 
-- **after_signal**: called after a signal is sent to a watcher's process. 
+- **after_signal**: called after a signal is sent to a watcher's process.
 
 - **extended_stats**: called when stats are requested with extended=True.
   Used for adding process-specific stats to the regular stats output.
@@ -48,11 +48,11 @@ you can order the startup by using the ``priority`` option:
 
     [watcher:queue-worker]
     cmd = python -u worker.py
-    priority = 2
+    priority = 1
 
     [watcher:redis]
     cmd = redis-server
-    priority = 1
+    priority = 2
 
 With this setup, Circus will start *Redis* first and then it will start the queue
 worker.  But Circus does not really control that *Redis* is up and
@@ -76,11 +76,11 @@ This function can be plugged into Circus as an ``before_start`` hook:
     [watcher:queue-worker]
     cmd = python -u worker.py
     hooks.before_start = mycoolapp.myplugins.check_redis
-    priority = 2
+    priority = 1
 
     [watcher:redis]
     cmd = redis-server
-    priority = 1
+    priority = 2
 
 
 Once Circus has started the **redis** watcher, it will start the
@@ -125,7 +125,7 @@ Likewise, **before_signal** and **after_signal** hooks add pid and signum::
 
 Where **pid** is the PID of the corresponding process and **signum** is the
 corresponding signal.
-        
+
 You can ignore those but being able to use the watcher and/or arbiter
 data and methods can be useful in some hooks.
 


### PR DESCRIPTION
# TL;DR

In `hooks.rst`, the `priority` settings are inverted in the examples (as written, the examples suggest that *lower* numbers are started first). This PR fixes the examples.

# Details

[`configuration.rst`](https://github.com/circus-tent/circus/blob/92aa3c6214e2730a7f67043268a636a5a233a4ce/docs/source/for-ops/configuration.rst) states (*emphasis* added):

> ***priority*** [¶] Integer that defines a priority for the watcher. When the Arbiter do some operations on all watchers, it will sort them with this field, *from the bigger number to the smallest*. Defaults to 0.

But [`hooks.rst`](https://github.com/circus-tent/circus/blob/92aa3c6214e2730a7f67043268a636a5a233a4ce/docs/source/for-devs/writing-hooks.rst) states:

>  With Circus you can order the startup by using the `priority` option: [¶] `...` [¶] With this setup, Circus will start Redis [with `priority = 1`] first and then it will start the queue worker [with `priority = 2`].

I haven't looked at the code, but my observation is that `configuration.rst`is correct and `hooks.rst` has it backwards. This PR fixes that by inverting the priority numbers used in the `hooks.rst` examples.