### PR TITLE
New option "close_child_stdin" for watchers

### DIFF
--- a/circus/commands/util.py
+++ b/circus/commands/util.py
@@ -53,6 +53,8 @@ def convert_option(key, val):
         return util.to_bool(val)
     elif key == "singleton":
         return util.to_bool(val)
+    elif key == "close_child_stdin":
+        return util.to_bool(val)
     elif key == "close_child_stdout":
         return util.to_bool(val)
     elif key == "close_child_stderr":

--- a/circus/commands/util.py
+++ b/circus/commands/util.py
@@ -98,8 +98,8 @@ def validate_option(key, val):
                   'shell', 'env', 'cmd', 'args', 'copy_env', 'retry_in',
                   'max_retry', 'graceful_timeout', 'stdout_stream',
                   'stderr_stream', 'max_age', 'max_age_variance', 'respawn',
-                  'singleton', 'hooks', 'close_child_stdout',
-                  'close_child_stderr')
+                  'singleton', 'hooks', 'close_child_stdin',
+                  'close_child_stdout', 'close_child_stderr')
 
     valid_prefixes = ('stdout_stream.', 'stderr_stream.', 'hooks.', 'rlimit_')
 
@@ -126,7 +126,8 @@ def validate_option(key, val):
             raise MessageError("%r isn't an integer or string" % key)
 
     elif key in ('send_hup', 'shell', 'copy_env', 'respawn', 'stop_children',
-                 'close_child_stdout', 'close_child_stderr'):
+                 'close_child_stdin', 'close_child_stdout',
+                 'close_child_stderr'):
         if not isinstance(val, bool):
             raise MessageError("%r isn't a valid boolean" % key)
 

--- a/circus/config.py
+++ b/circus/config.py
@@ -259,7 +259,8 @@ def get_config(config_file):
 
                     watcher['hooks'][hook_name] = val
                 # default bool to True
-                elif opt in ('check_flapping', 'respawn', 'autostart'):
+                elif opt in ('check_flapping', 'respawn', 'autostart',
+                             'close_child_stdin'):
                     watcher[opt] = dget(section, opt, True, bool)
                 else:
                     # freeform

--- a/circus/process.py
+++ b/circus/process.py
@@ -161,6 +161,9 @@ class Process(object):
 
     - **pipe_stderr**: if True, will open a PIPE on stderr. default: True.
 
+    - **close_child_stdin**: If True, redirects the child process' stdin
+      to /dev/null after the fork. default: True.
+
     - **close_child_stdout**: If True, redirects the child process' stdout
       to /dev/null after the fork. default: False.
 
@@ -170,7 +173,7 @@ class Process(object):
     def __init__(self, name, wid, cmd, args=None, working_dir=None,
                  shell=False, uid=None, gid=None, env=None, rlimits=None,
                  executable=None, use_fds=False, watcher=None, spawn=True,
-                 pipe_stdout=True, pipe_stderr=True,
+                 pipe_stdout=True, pipe_stderr=True, close_child_stdin=True,
                  close_child_stdout=False, close_child_stderr=False):
 
         self.name = name
@@ -193,6 +196,7 @@ class Process(object):
         self.watcher = watcher
         self.pipe_stdout = pipe_stdout
         self.pipe_stderr = pipe_stderr
+        self.close_child_stdin = close_child_stdin
         self.close_child_stdout = close_child_stdout
         self.close_child_stderr = close_child_stderr
         self.stopping = False
@@ -263,7 +267,10 @@ class Process(object):
         args = self.format_args(sockets_fds=sockets_fds)
 
         def preexec():
-            streams = [sys.stdin]
+            streams = []
+
+            if self.close_child_stdin:
+                streams.append(sys.stdin)
 
             if self.close_child_stdout:
                 streams.append(sys.stdout)

--- a/circus/watcher.py
+++ b/circus/watcher.py
@@ -179,6 +179,9 @@ class Watcher(object):
     - **virtualenv** -- The root directory of a virtualenv. If provided, the
       watcher will load the environment for its execution. (default: None)
 
+    - **close_child_stdin**: If True, closes the stdin after the fork.
+      default: True.
+
     - **close_child_stdout**: If True, closes the stdout after the fork.
       default: False.
 
@@ -199,8 +202,9 @@ class Watcher(object):
                  copy_env=False, copy_path=False, max_age=0,
                  max_age_variance=30, hooks=None, respawn=True,
                  autostart=True, on_demand=False, virtualenv=None,
-                 close_child_stdout=False, close_child_stderr=False,
-                 virtualenv_py_ver=None, use_papa=False, **options):
+                 close_child_stdin=True, close_child_stdout=False,
+                 close_child_stderr=False, virtualenv_py_ver=None,
+                 use_papa=False, **options):
         self.name = name
         self.use_sockets = use_sockets
         self.on_demand = on_demand
@@ -234,6 +238,7 @@ class Watcher(object):
 
         self.respawn = respawn
         self.autostart = autostart
+        self.close_child_stdin = close_child_stdin
         self.close_child_stdout = close_child_stdout
         self.close_child_stderr = close_child_stderr
         self.use_papa = use_papa and papa is not None
@@ -263,8 +268,9 @@ class Watcher(object):
                           "priority", "copy_env", "singleton",
                           "stdout_stream_conf", "on_demand",
                           "stderr_stream_conf", "max_age", "max_age_variance",
-                          "close_child_stdout", "close_child_stderr",
-                          "use_papa") + tuple(options.keys()))
+                          "close_child_stdin", "close_child_stdout",
+                          "close_child_stderr", "use_papa") + \
+                          tuple(options.keys()))
 
         if not working_dir:
             # working dir hasn't been set
@@ -643,6 +649,7 @@ class Watcher(object):
                                   use_fds=self.use_sockets, watcher=self,
                                   pipe_stdout=pipe_stdout,
                                   pipe_stderr=pipe_stderr,
+                                  close_child_stdin=self.close_child_stdin,
                                   close_child_stdout=self.close_child_stdout,
                                   close_child_stderr=self.close_child_stderr)
 

--- a/circus/watcher.py
+++ b/circus/watcher.py
@@ -269,8 +269,8 @@ class Watcher(object):
                           "stdout_stream_conf", "on_demand",
                           "stderr_stream_conf", "max_age", "max_age_variance",
                           "close_child_stdin", "close_child_stdout",
-                          "close_child_stderr", "use_papa") + \
-                          tuple(options.keys()))
+                          "close_child_stderr", "use_papa") +
+                         tuple(options.keys()))
 
         if not working_dir:
             # working dir hasn't been set

--- a/docs/source/for-ops/configuration.rst
+++ b/docs/source/for-ops/configuration.rst
@@ -234,6 +234,10 @@ watcher:NAME - as many sections as you want
         be passed the constructor when creating an instance of the
         class defined in **stdout_stream.class**.
 
+    **close_child_stdin**
+        If set to True, the stdin stream of each process will be sent to
+        /dev/null after the fork. Defaults to True.
+
     **close_child_stdout**
         If set to True, the stdout stream of each process will be sent to
         /dev/null after the fork. Defaults to False.

--- a/docs/source/for-ops/configuration.rst
+++ b/docs/source/for-ops/configuration.rst
@@ -73,7 +73,7 @@ circus - single section
         The ZMQ PUB/SUB socket receiving publications of stats.
         (default: *tcp://127.0.0.1:5557*)
     **statsd_close_outputs**
-        If True sends the circusd-stats stdout/stderr to /dev/null.
+        If True sends the circusd-stats stdout/stderr to ``/dev/null``.
         (default: False)
     **check_delay**
         The polling interval in seconds for the ZMQ socket. (default: 5)
@@ -97,7 +97,7 @@ circus - single section
     **httpd_port**
         The port ran by the circushttpd daemon. (default: 8080)
     **httpd_close_outputs**
-        If True, sends the circushttpd stdout/stderr to /dev/null.
+        If True, sends the circushttpd stdout/stderr to ``/dev/null``.
         (default: False)
     **debug**
         If set to True, all Circus stout/stderr daemons are redirected to circusd
@@ -236,15 +236,27 @@ watcher:NAME - as many sections as you want
 
     **close_child_stdin**
         If set to True, the stdin stream of each process will be sent to
-        /dev/null after the fork. Defaults to True.
+        ``/dev/null`` after the fork. Defaults to True.
+
+        The primary use case for this option is debugging. Set it to False and
+        Circus will leave *stdin* open for the watcher processes. This allows
+        interactive debugger sessions to be attached to them. In case of a
+        Python program, one could insert a Pdb call (``import pdb;
+        pdb.set_trace()``) somewhere in the code and acquire its shell to
+        debug the program.
+
+        If debugging a process is not expected, leave this option in its default
+        value, True. This will prevent, for example, that the process hangs
+        indefinitely waiting on input which could never come, especially if
+        Circus runs as a daemon.
 
     **close_child_stdout**
         If set to True, the stdout stream of each process will be sent to
-        /dev/null after the fork. Defaults to False.
+        ``/dev/null`` after the fork. Defaults to False.
 
     **close_child_stderr**
         If set to True, the stderr stream of each process will be sent to
-        /dev/null after the fork. Defaults to False.
+        ``/dev/null`` after the fork. Defaults to False.
 
     **send_hup**
         If True, a process reload will be done by sending the SIGHUP signal.


### PR DESCRIPTION
Circus, by default, always closes the "stdin" of the processes it forks.
While this might be good for a production setting, in development it is
not unusual to debug programs with

  import pdb; pdb.set_trace()

This will not work in processes spawned by Circus. Pdb raises a BdbQuit
exception on that instruction, since it can't receive user input.

The new option "close_child_stdin" is false, by default. This preserves
current Circus behaviour. Set it to true in a watcher configuration to
be able to attach an iteractive debugger session to its processes.