### PR TITLE
Include assets

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include CONTRIBUTORS.txt
 include README.rst
 include LICENSE
 include pip-requirements.txt
+recursive-include examples *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include CONTRIBUTORS.txt
 include README.rst
 include LICENSE
 include pip-requirements.txt
+include tox.ini
 recursive-include examples *
 recursive-include docs *
 recursive-include extras *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ include README.rst
 include LICENSE
 include pip-requirements.txt
 recursive-include examples *
+recursive-include docs *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,4 @@ include LICENSE
 include pip-requirements.txt
 recursive-include examples *
 recursive-include docs *
+recursive-include extras *

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open("README.rst") as f:
 
 setup(name='circus',
       version=__version__,
-      packages=find_packages(exclude=["docs"]),
+      packages=find_packages(exclude=["docs", "examples", "examples.*"]),
       description=("Circus is a program that will let you run and watch "
                    " multiple processes and sockets."),
       long_description=README,


### PR DESCRIPTION
This would be nice-to-have for distribution (e.g. Debian) packages of circus to build the documentation, run the tests or provide working examples for circus.