### PR TITLE
Match lower case when start/stop/restart a watcher

### DIFF
--- a/circus/commands/restart.py
+++ b/circus/commands/restart.py
@@ -18,10 +18,11 @@ def execute_watcher_start_stop_restart(command, arbiter, props,
         if match == 'simple':
             watchers = [command._get_watcher(arbiter, props['name'])]
         else:
+            watcher_name = props['name'].lower()
             if match == 'glob':
-                name = re.compile(fnmatch.translate(props['name']))
+                name = re.compile(fnmatch.translate(watcher_name))
             elif match == 'regex':
-                name = re.compile(props['name'])
+                name = re.compile(watcher_name)
             else:
                 raise MessageError("unknown match method %s" % match)
             watchers = [watcher


### PR DESCRIPTION
Always match lower case watcher name when stop/start/restart a watcher.

Option 1 suggested by @k4n4r in issue circus-tent/circus#927