### PR TITLE
Fix issue #686 for `circusctl` as well

### DIFF
--- a/circus/commands/decrproc.py
+++ b/circus/commands/decrproc.py
@@ -48,8 +48,11 @@ class DecrProcess(IncrProc):
 
     def execute(self, arbiter, props):
         watcher = self._get_watcher(arbiter, props.get('name'))
-        nb = props.get('nb', 1)
-        resp = TransformableFuture()
-        resp.set_upstream_future(watcher.decr(nb))
-        resp.set_transform_function(lambda x: {"numprocesses": x})
-        return resp
+        if watcher.singleton:
+            return {"numprocesses": watcher.numprocesses, "singleton": True}
+        else:
+            nb = props.get('nb', 1)
+            resp = TransformableFuture()
+            resp.set_upstream_future(watcher.decr(nb))
+            resp.set_transform_function(lambda x: {"numprocesses": x})
+            return resp

--- a/circus/commands/decrproc.py
+++ b/circus/commands/decrproc.py
@@ -2,7 +2,7 @@ from circus.commands.incrproc import IncrProc
 from circus.util import TransformableFuture
 
 
-class DecrProcess(IncrProc):
+class DecrProc(IncrProc):
     """\
         Decrement the number of processes in a watcher
         ==============================================

--- a/circus/tests/test_command_decrproc.py
+++ b/circus/tests/test_command_decrproc.py
@@ -1,4 +1,4 @@
-from circus.tests.test_command_incrproc import FakeArbiter
+from circus.tests.test_command_incrproc import FakeArbiter, FakeSingletonWatcher
 from circus.tests.support import TestCircus, EasyTestSuite
 from circus.commands.decrproc import DecrProcess
 
@@ -8,10 +8,20 @@ class DecrProcTest(TestCircus):
     def test_decr_proc(self):
         cmd = DecrProcess()
         arbiter = FakeArbiter()
-        self.assertTrue(arbiter.watchers[0].nb, 1)
+        self.assertTrue(arbiter.watchers[0].numprocesses, 1)
 
         props = cmd.message('dummy')['properties']
         cmd.execute(arbiter, props)
-        self.assertEqual(arbiter.watchers[0].nb, 0)
+        self.assertEqual(arbiter.watchers[0].numprocesses, 0)
+
+    def test_decr_proc_singleton(self):
+        cmd = DecrProcess()
+        arbiter = FakeArbiter(watcher_class=FakeSingletonWatcher)
+        size_before = arbiter.watchers[0].numprocesses
+
+        props = cmd.message('dummy', 3)['properties']
+        cmd.execute(arbiter, props)
+        self.assertEqual(arbiter.watchers[0].numprocesses, size_before)
+
 
 test_suite = EasyTestSuite(__name__)

--- a/circus/tests/test_command_decrproc.py
+++ b/circus/tests/test_command_decrproc.py
@@ -1,12 +1,12 @@
 from circus.tests.test_command_incrproc import FakeArbiter, FakeSingletonWatcher
 from circus.tests.support import TestCircus, EasyTestSuite
-from circus.commands.decrproc import DecrProcess
+from circus.commands.decrproc import DecrProc
 
 
 class DecrProcTest(TestCircus):
 
     def test_decr_proc(self):
-        cmd = DecrProcess()
+        cmd = DecrProc()
         arbiter = FakeArbiter()
         self.assertTrue(arbiter.watchers[0].numprocesses, 1)
 
@@ -15,7 +15,7 @@ class DecrProcTest(TestCircus):
         self.assertEqual(arbiter.watchers[0].numprocesses, 0)
 
     def test_decr_proc_singleton(self):
-        cmd = DecrProcess()
+        cmd = DecrProc()
         arbiter = FakeArbiter(watcher_class=FakeSingletonWatcher)
         size_before = arbiter.watchers[0].numprocesses
 

--- a/circus/tests/test_command_incrproc.py
+++ b/circus/tests/test_command_incrproc.py
@@ -5,7 +5,9 @@ from circus.commands.incrproc import IncrProc
 class FakeWatcher(object):
     name = 'one'
     singleton = False
-    nb = 1
+
+    def __init__(self):
+        self.numprocesses = 1
 
     def info(self, *args):
         if len(args) == 1 and args[0] == 'meh':
@@ -15,10 +17,15 @@ class FakeWatcher(object):
     process_info = info
 
     def incr(self, nb):
-        self.nb += nb
+        self.numprocesses += nb
 
     def decr(self, nb):
-        self.nb -= nb
+        self.numprocesses -= nb
+
+
+class FakeSingletonWatcher(FakeWatcher):
+    name = 'two'
+    singleton = True
 
 
 class FakeLoop(object):
@@ -28,10 +35,8 @@ class FakeLoop(object):
 
 class FakeArbiter(object):
 
-    watcher_class = FakeWatcher
-
-    def __init__(self):
-        self.watchers = [self.watcher_class()]
+    def __init__(self, watcher_class=FakeWatcher):
+        self.watchers = [watcher_class()]
         self.loop = FakeLoop()
 
     def get_watcher(self, name):
@@ -58,10 +63,20 @@ class IncrProcTest(TestCircus):
     def test_incr_proc(self):
         cmd = IncrProc()
         arbiter = FakeArbiter()
-        size_before = arbiter.watchers[0].nb
+        size_before = arbiter.watchers[0].numprocesses
 
         props = cmd.message('dummy', 3)['properties']
         cmd.execute(arbiter, props)
-        self.assertEqual(arbiter.watchers[0].nb, size_before + 3)
+        self.assertEqual(arbiter.watchers[0].numprocesses, size_before + 3)
+
+    def test_incr_proc_singleton(self):
+        cmd = IncrProc()
+        arbiter = FakeArbiter(watcher_class=FakeSingletonWatcher)
+        size_before = arbiter.watchers[0].numprocesses
+
+        props = cmd.message('dummy', 3)['properties']
+        cmd.execute(arbiter, props)
+        self.assertEqual(arbiter.watchers[0].numprocesses, size_before)
+
 
 test_suite = EasyTestSuite(__name__)

--- a/circus/tests/test_command_quit.py
+++ b/circus/tests/test_command_quit.py
@@ -7,7 +7,7 @@ class QuitTest(TestCircus):
     def test_quit(self):
         cmd = Quit()
         arbiter = FakeArbiter()
-        self.assertTrue(arbiter.watchers[0].nb, 1)
+        self.assertTrue(arbiter.watchers[0].numprocesses, 1)
         props = cmd.message('dummy')['properties']
         cmd.execute(arbiter, props)
         self.assertEqual(len(arbiter.watchers), 0)

--- a/circus/tests/test_command_set.py
+++ b/circus/tests/test_command_set.py
@@ -1,5 +1,5 @@
 from circus.tests.support import TestCircus, EasyTestSuite
-from circus.tests.test_command_incrproc import FakeArbiter as _FakeArbiter
+from circus.tests.test_command_incrproc import FakeArbiter
 from circus.commands.set import Set
 
 
@@ -15,14 +15,10 @@ class FakeWatcher(object):
         self.actions.append(action)
 
 
-class FakeArbiter(_FakeArbiter):
-    watcher_class = FakeWatcher
-
-
 class SetTest(TestCircus):
 
     def test_set_stream(self):
-        arbiter = FakeArbiter()
+        arbiter = FakeArbiter(watcher_class=FakeWatcher)
         cmd = Set()
 
         # setting streams
@@ -55,7 +51,7 @@ class SetTest(TestCircus):
                          'hook')
 
     def test_set_args(self):
-        arbiter = FakeArbiter()
+        arbiter = FakeArbiter(watcher_class=FakeWatcher)
         cmd = Set()
 
         props = cmd.message('dummy2', 'args', '--arg1 1 --arg2 2')


### PR DESCRIPTION
Issue #686 was partially fixed by disabling the decr link in circus-web but the problematic behaviour is still accessible through `circusctl decr` and presumably raw 0MQ.

This PR:
- Implements the same singleton checking logic as `IncrProc` in `DecrProcess`
- Renames `DecrProcess` to `DecrProc` for consistency
- Adds tests for the correct behaviour in both commands given singleton watchers.