### PR TITLE
Fix issue #686 for circusctl as well (refactored)

### DIFF
--- a/circus/commands/decrproc.py
+++ b/circus/commands/decrproc.py
@@ -48,8 +48,11 @@ class DecrProcess(IncrProc):
 
     def execute(self, arbiter, props):
         watcher = self._get_watcher(arbiter, props.get('name'))
-        nb = props.get('nb', 1)
-        resp = TransformableFuture()
-        resp.set_upstream_future(watcher.decr(nb))
-        resp.set_transform_function(lambda x: {"numprocesses": x})
-        return resp
+        if watcher.singleton:
+            return {"numprocesses": watcher.numprocesses, "singleton": True}
+        else:
+            nb = props.get('nb', 1)
+            resp = TransformableFuture()
+            resp.set_upstream_future(watcher.decr(nb))
+            resp.set_transform_function(lambda x: {"numprocesses": x})
+            return resp

--- a/circus/commands/decrproc.py
+++ b/circus/commands/decrproc.py
@@ -2,7 +2,7 @@ from circus.commands.incrproc import IncrProc
 from circus.util import TransformableFuture
 
 
-class DecrProcess(IncrProc):
+class DecrProc(IncrProc):
     """\
         Decrement the number of processes in a watcher
         ==============================================

--- a/circus/tests/test_command_decrproc.py
+++ b/circus/tests/test_command_decrproc.py
@@ -8,10 +8,10 @@ class DecrProcTest(TestCircus):
     def test_decr_proc(self):
         cmd = DecrProcess()
         arbiter = FakeArbiter()
-        self.assertTrue(arbiter.watchers[0].nb, 1)
+        self.assertTrue(arbiter.watchers[0].numprocesses, 1)
 
         props = cmd.message('dummy')['properties']
         cmd.execute(arbiter, props)
-        self.assertEqual(arbiter.watchers[0].nb, 0)
+        self.assertEqual(arbiter.watchers[0].numprocesses, 0)
 
 test_suite = EasyTestSuite(__name__)

--- a/circus/tests/test_command_decrproc.py
+++ b/circus/tests/test_command_decrproc.py
@@ -1,4 +1,5 @@
-from circus.tests.test_command_incrproc import FakeArbiter
+from circus.tests.test_command_incrproc import (FakeArbiter,
+        FakeArbiterWithSingletonWatchers)
 from circus.tests.support import TestCircus, EasyTestSuite
 from circus.commands.decrproc import DecrProcess
 
@@ -13,5 +14,15 @@ class DecrProcTest(TestCircus):
         props = cmd.message('dummy')['properties']
         cmd.execute(arbiter, props)
         self.assertEqual(arbiter.watchers[0].numprocesses, 0)
+
+    def test_decr_proc_singleton(self):
+        cmd = DecrProcess()
+        arbiter = FakeArbiterWithSingletonWatchers()
+        size_before = arbiter.watchers[0].numprocesses
+
+        props = cmd.message('dummy', 3)['properties']
+        cmd.execute(arbiter, props)
+        self.assertEqual(arbiter.watchers[0].numprocesses, size_before)
+
 
 test_suite = EasyTestSuite(__name__)

--- a/circus/tests/test_command_decrproc.py
+++ b/circus/tests/test_command_decrproc.py
@@ -1,13 +1,13 @@
 from circus.tests.test_command_incrproc import (FakeArbiter,
         FakeArbiterWithSingletonWatchers)
 from circus.tests.support import TestCircus, EasyTestSuite
-from circus.commands.decrproc import DecrProcess
+from circus.commands.decrproc import DecrProc
 
 
 class DecrProcTest(TestCircus):
 
     def test_decr_proc(self):
-        cmd = DecrProcess()
+        cmd = DecrProc()
         arbiter = FakeArbiter()
         self.assertTrue(arbiter.watchers[0].numprocesses, 1)
 
@@ -16,7 +16,7 @@ class DecrProcTest(TestCircus):
         self.assertEqual(arbiter.watchers[0].numprocesses, 0)
 
     def test_decr_proc_singleton(self):
-        cmd = DecrProcess()
+        cmd = DecrProc()
         arbiter = FakeArbiterWithSingletonWatchers()
         size_before = arbiter.watchers[0].numprocesses
 

--- a/circus/tests/test_command_incrproc.py
+++ b/circus/tests/test_command_incrproc.py
@@ -5,7 +5,9 @@ from circus.commands.incrproc import IncrProc
 class FakeWatcher(object):
     name = 'one'
     singleton = False
-    nb = 1
+
+    def __init__(self):
+        self.numprocesses = 1
 
     def info(self, *args):
         if len(args) == 1 and args[0] == 'meh':
@@ -15,10 +17,10 @@ class FakeWatcher(object):
     process_info = info
 
     def incr(self, nb):
-        self.nb += nb
+        self.numprocesses += nb
 
     def decr(self, nb):
-        self.nb -= nb
+        self.numprocesses -= nb
 
 
 class FakeLoop(object):
@@ -58,10 +60,10 @@ class IncrProcTest(TestCircus):
     def test_incr_proc(self):
         cmd = IncrProc()
         arbiter = FakeArbiter()
-        size_before = arbiter.watchers[0].nb
+        size_before = arbiter.watchers[0].numprocesses
 
         props = cmd.message('dummy', 3)['properties']
         cmd.execute(arbiter, props)
-        self.assertEqual(arbiter.watchers[0].nb, size_before + 3)
+        self.assertEqual(arbiter.watchers[0].numprocesses, size_before + 3)
 
 test_suite = EasyTestSuite(__name__)

--- a/circus/tests/test_command_incrproc.py
+++ b/circus/tests/test_command_incrproc.py
@@ -23,6 +23,10 @@ class FakeWatcher(object):
         self.numprocesses -= nb
 
 
+class FakeSingletonWatcher(FakeWatcher):
+    singleton = True
+
+
 class FakeLoop(object):
     def add_callback(self, function):
         function()
@@ -46,6 +50,10 @@ class FakeArbiter(object):
         self.stop_watchers(**options)
 
 
+class FakeArbiterWithSingletonWatchers(FakeArbiter):
+    watcher_class = FakeSingletonWatcher
+
+
 class IncrProcTest(TestCircus):
 
     def test_incr_proc_message(self):
@@ -65,5 +73,15 @@ class IncrProcTest(TestCircus):
         props = cmd.message('dummy', 3)['properties']
         cmd.execute(arbiter, props)
         self.assertEqual(arbiter.watchers[0].numprocesses, size_before + 3)
+
+    def test_incr_proc_singleton(self):
+        cmd = IncrProc()
+        arbiter = FakeArbiterWithSingletonWatchers()
+        size_before = arbiter.watchers[0].numprocesses
+
+        props = cmd.message('dummy', 3)['properties']
+        cmd.execute(arbiter, props)
+        self.assertEqual(arbiter.watchers[0].numprocesses, size_before)
+
 
 test_suite = EasyTestSuite(__name__)

--- a/circus/tests/test_command_quit.py
+++ b/circus/tests/test_command_quit.py
@@ -7,7 +7,7 @@ class QuitTest(TestCircus):
     def test_quit(self):
         cmd = Quit()
         arbiter = FakeArbiter()
-        self.assertTrue(arbiter.watchers[0].nb, 1)
+        self.assertTrue(arbiter.watchers[0].numprocesses, 1)
         props = cmd.message('dummy')['properties']
         cmd.execute(arbiter, props)
         self.assertEqual(len(arbiter.watchers), 0)


### PR DESCRIPTION
Issue #686 was partially fixed by disabling the decr link in circus-web but the problematic behaviour is still accessible through `circusctl decr` and presumably raw ZMQ.

This replaces PR #931.

Just like 931 it:
- Renames `DecrProcess` to `DecrProc` for consistency with `IncrProc`
- Implements the same singleton checking logic as `IncrProc` in `DecrProc`
- Adds tests for the correct behaviour in both commands given singleton watchers

Contrary to 931, to address @douardda's comment on 931, it:
- Spreads the changes across 4 commits instead of 2
- Uses a subclass of `FakeArbiter` to support singleton `FakeWatcher`s, instead of refactoring `FakeArbiter` to support dependency injection of the watcher class.  This is similar to how `test_command_set.py` subclasses `FakeArbiter` and does not affect any of the other test files that import `FakeArbiter` from `test_command_incr.py`.