### PR TITLE
[Continuation of #938] New 'kill' command used by Watchdog to gracefully stop the processes

### DIFF
--- a/circus/commands/__init__.py
+++ b/circus/commands/__init__.py
@@ -6,6 +6,7 @@ from circus.commands import (   # NOQA
     globaloptions,
     incrproc,
     ipythonshell,
+    kill,
     list,
     listen,
     listsockets,

--- a/circus/commands/kill.py
+++ b/circus/commands/kill.py
@@ -1,0 +1,109 @@
+from circus.commands.base import Command
+from circus.exc import ArgumentError, MessageError
+from circus.util import to_signum
+from tornado import gen
+
+
+class Kill(Command):
+    """\
+        Kill a specific process
+        =======================
+
+        This command allows you to terminate a process in a watcher. If a
+        process does not exit within graceful_timeout it will be terminated
+        with a SIGKILL.
+
+        ZMQ Message
+        -----------
+
+        To kill all the processes of a watcher::
+
+            {
+                "command": "kill",
+                "property": {
+                    "name": <name>,
+                    "signum": <signum>,
+                    "graceful_timeout": <graceful_timeout>
+                }
+            }
+
+        To send a signal to a specific process::
+
+            {
+                "command": "kill",
+                "property": {
+                    "name": <name>,
+                    "pid": <processid>,
+                    "signum": <signum>,
+                    "graceful_timeout": <graceful_timeout>
+                }
+            }
+
+
+        Command line
+        ------------
+
+        ::
+
+            $ circusctl kill <name> [<pid>] [<signum>] [<graceful_timeout>]
+
+        Options:
+        ++++++++
+
+        - <name>: the name of the watcher
+        - <pid>: integer, the process id
+        - <signum>: overrides the watcher's stop_signal (number or name)
+        - <graceful_timeout>: overrides the watcher's graceful_timeout
+
+    """
+
+    name = "kill"
+    properties = ['name']
+
+    def message(self, *args, **opts):
+        largs = len(args)
+        if largs < 1 or largs > 4:
+            raise ArgumentError("Invalid number of arguments")
+
+        props = {
+            'name': args[0],
+        }
+        if len(args) >= 2:
+            props['pid'] = args[1]
+        if len(args) >= 3:
+            props['signum'] = args[2]
+        if len(args) >= 4:
+            props['graceful_timeout'] = args[3]
+        return self.make_message(**props)
+
+    @gen.coroutine
+    def execute(self, arbiter, props):
+        name = props.get('name')
+        pid = props.get('pid')
+        signum = props.get('signum')
+        graceful_timeout = props.get('graceful_timeout')
+
+        watcher = self._get_watcher(arbiter, name)
+        processes = watcher.get_active_processes()
+        if pid:
+            processes = [p for p in processes if p.pid == pid]
+
+        if processes:
+            yield [watcher.kill_process(p,
+                                        stop_signal=signum,
+                                        graceful_timeout=graceful_timeout)
+                   for p in processes]
+
+    def validate(self, props):
+        super(Kill, self).validate(props)
+
+        if 'pid' in props:
+            props['pid'] = int(props['pid'])
+        if 'graceful_timeout' in props:
+            props['graceful_timeout'] = float(props['graceful_timeout'])
+
+        try:
+            if 'signum' in props:
+                props['signum'] = to_signum(props['signum'])
+        except ValueError:
+            raise MessageError('signal invalid')

--- a/circus/tests/test_command_kill.py
+++ b/circus/tests/test_command_kill.py
@@ -1,0 +1,130 @@
+import sys
+import time
+import signal
+import tornado
+import tornado.gen
+
+from circus.tests.support import TestCircus, TimeoutException
+from circus.tests.support import skipIf, IS_WINDOWS
+from circus.client import AsyncCircusClient
+from circus.stream import QueueStream, Empty
+from circus.util import tornado_sleep
+
+
+def send(msg):
+    sys.stdout.write(msg + '\n')
+    sys.stdout.flush()
+
+
+def obedient_process(*args, **kwargs):
+    """Waits for SIGINT and exits normally"""
+    stopped = []
+
+    def handler(sig, frame):
+        send('SIGINT')
+        stopped.append(1)
+
+    signal.signal(signal.SIGINT, handler)
+
+    send('STARTED')
+    while not stopped:
+        signal.pause()
+    send('STOPPED')
+
+
+def hanged_process(*args, **kwargs):
+    """Ignores SIGINT signal"""
+    def handler(sig, frame):
+        send('SIGINT')
+        # ignore
+
+    signal.signal(signal.SIGINT, handler)
+
+    send('STARTED')
+    while True:
+        signal.pause()
+    send('STOPPED')
+
+
+class StreamReader(object):
+    def __init__(self, stream, timeout=5):
+        self._stream = stream
+        self._timeout = timeout
+        self._buffer = []
+
+    @tornado.gen.coroutine
+    def read(self, timeout=None):
+        timeout = timeout or self._timeout
+
+        if self._buffer:
+            raise tornado.gen.Return(self._buffer.pop(0))
+
+        start = time.time()
+        while time.time() - start < timeout:
+            try:
+                msg = self._stream.get_nowait()
+                lines = [l for l in msg['data'].split('\n') if l]
+                self._buffer.extend(lines)
+                raise tornado.gen.Return(self._buffer.pop(0))
+            except Empty:
+                yield tornado_sleep(0.1)
+        raise TimeoutException('Timeout reading queue')
+
+
+class KillCommandTest(TestCircus):
+
+    @skipIf(IS_WINDOWS, "Streams not supported")
+    def setUp(self):
+        super(KillCommandTest, self).setUp()
+        self.stream = QueueStream()
+        self.reader = StreamReader(self.stream)
+        self._client = None
+
+    @property
+    def client(self):
+        if not self._client:
+            self._client = AsyncCircusClient(endpoint=self.arbiter.endpoint)
+        return self._client
+
+    @tornado.gen.coroutine
+    def assertMessage(self, msg, timeout=5):
+        try:
+            actual = yield self.reader.read(timeout=timeout)
+        except TimeoutException:
+            raise AssertionError('Timeout while waiting for message: {}'
+                                 .format(msg))
+
+        self.assertEqual(actual, msg)
+
+    @tornado.testing.gen_test
+    def test_exits_within_graceful_timeout(self):
+        yield self.start_arbiter(
+            cmd='circus.tests.test_command_kill.obedient_process',
+            stdout_stream={'stream': self.stream},
+            stderr_stream={'stream': self.stream})
+
+        yield self.assertMessage('STARTED')
+
+        res = yield self.client.send_message(
+            'kill', name='test', signum='sigint',
+            graceful_timeout=0.1, waiting=True)
+        self.assertEqual(res['status'], 'ok')
+
+        yield self.assertMessage('SIGINT')
+        yield self.assertMessage('STOPPED')
+
+    @tornado.testing.gen_test
+    def test_kills_after_graceful_timeout(self):
+        yield self.start_arbiter(
+            cmd='circus.tests.test_command_kill.hanged_process',
+            stdout_stream={'stream': self.stream},
+            stderr_stream={'stream': self.stream})
+
+        yield self.assertMessage('STARTED')
+
+        res = yield self.client.send_message(
+            'kill', name='test', signum='sigint',
+            graceful_timeout=0.1, waiting=True)
+        self.assertEqual(res['status'], 'ok')
+
+        yield self.assertMessage('SIGINT')

--- a/circus/tests/test_command_kill.py
+++ b/circus/tests/test_command_kill.py
@@ -9,6 +9,7 @@ from circus.tests.support import skipIf, IS_WINDOWS
 from circus.client import AsyncCircusClient
 from circus.stream import QueueStream, Empty
 from circus.util import tornado_sleep
+from circus.py3compat import s
 
 
 def send(msg):
@@ -63,7 +64,7 @@ class StreamReader(object):
         while time.time() - start < timeout:
             try:
                 msg = self._stream.get_nowait()
-                lines = [l for l in msg['data'].split('\n') if l]
+                lines = [l for l in s(msg['data']).split('\n') if l]
                 self._buffer.extend(lines)
                 raise tornado.gen.Return(self._buffer.pop(0))
             except Empty:

--- a/circus/watcher.py
+++ b/circus/watcher.py
@@ -707,7 +707,8 @@ class Watcher(object):
     def kill_process(self, process, stop_signal=None, graceful_timeout=None):
         """Kill process (stop_signal, graceful_timeout then SIGKILL)
         """
-        stop_signal = stop_signal or self.stop_signal
+        if stop_signal is None:
+            stop_signal = self.stop_signal
         if graceful_timeout is None:
             graceful_timeout = self.graceful_timeout
 

--- a/circus/watcher.py
+++ b/circus/watcher.py
@@ -704,17 +704,21 @@ class Watcher(object):
 
     @gen.coroutine
     @util.debuglog
-    def kill_process(self, process):
+    def kill_process(self, process, stop_signal=None, graceful_timeout=None):
         """Kill process (stop_signal, graceful_timeout then SIGKILL)
         """
+        stop_signal = stop_signal or self.stop_signal
+        if graceful_timeout is None:
+            graceful_timeout = self.graceful_timeout
+
         if process.stopping:
             raise gen.Return(False)
         try:
             logger.debug("%s: kill process %s", self.name, process.pid)
             if self.stop_children:
-                self.send_signal_process(process, self.stop_signal)
+                self.send_signal_process(process, stop_signal)
             else:
-                self.send_signal(process.pid, self.stop_signal)
+                self.send_signal(process.pid, stop_signal)
                 self.notify_event("kill", {"process_pid": process.pid,
                                            "time": time.time()})
         except NoSuchProcess:
@@ -722,12 +726,12 @@ class Watcher(object):
 
         process.stopping = True
         waited = 0
-        while waited < self.graceful_timeout:
+        while waited < graceful_timeout:
             if not process.is_alive():
                 break
             yield tornado_sleep(0.1)
             waited += 0.1
-        if waited >= self.graceful_timeout:
+        if waited >= graceful_timeout:
             # On Windows we can't send a SIGKILL signal, but the
             # process.stop function will terminate the process
             # later anyway
@@ -742,12 +746,15 @@ class Watcher(object):
 
     @gen.coroutine
     @util.debuglog
-    def kill_processes(self):
+    def kill_processes(self, stop_signal=None, graceful_timeout=None):
         """Kill all processes (stop_signal, graceful_timeout then SIGKILL)
         """
         active_processes = self.get_active_processes()
         try:
-            yield [self.kill_process(process) for process in active_processes]
+            yield [self.kill_process(process,
+                                     stop_signal=stop_signal,
+                                     graceful_timeout=graceful_timeout)
+                   for process in active_processes]
         except OSError as e:
             if e.errno != errno.ESRCH:
                 raise


### PR DESCRIPTION
Continuation of #938 

This sets `graceful_timeout` and `signum` as options instead of positional arguments, and fixes the tests for Python 3.