### PR TITLE
Guard against accidental empty ini sections

### DIFF
--- a/circus/config.py
+++ b/circus/config.py
@@ -189,15 +189,19 @@ def get_config(config_file):
     sockets = []
 
     for section in cfg.sections():
+        section_items = dict(cfg.items(section))
+        if list(section_items.keys()) in [[], ['__name__']]:
+            # Skip empty sections
+            continue
         if section.startswith("socket:"):
-            sock = dict(cfg.items(section))
+            sock = section_items
             sock['name'] = section.split("socket:")[-1].lower()
             sock['so_reuseport'] = dget(section, "so_reuseport", False, bool)
             sock['replace'] = dget(section, "replace", False, bool)
             sockets.append(sock)
 
         if section.startswith("plugin:"):
-            plugin = dict(cfg.items(section))
+            plugin = section_items
             plugin['name'] = section
             if 'priority' in plugin:
                 plugin['priority'] = int(plugin['priority'])

--- a/circus/tests/config/empty_section.ini
+++ b/circus/tests/config/empty_section.ini
@@ -1,0 +1,4 @@
+
+[plugin:test_plugin]
+
+[socket:test_socket]

--- a/circus/tests/test_config.py
+++ b/circus/tests/test_config.py
@@ -43,6 +43,7 @@ _CONF = {
     'issue665': os.path.join(CONFIG_DIR, 'issue665.ini'),
     'issue680': os.path.join(CONFIG_DIR, 'issue680.ini'),
     'virtualenv': os.path.join(CONFIG_DIR, 'virtualenv.ini'),
+    'empty_section': os.path.join(CONFIG_DIR, 'empty_section.ini'),
 }
 
 
@@ -371,6 +372,11 @@ class TestConfig(TestCase):
         watcher = conf['watchers'][0]
         self.assertEqual(watcher['virtualenv'], "/tmp/.virtualenvs/test")
         self.assertEqual(watcher['virtualenv_py_ver'], "3.3")
+
+    def test_empty_section(self):
+        conf = get_config(_CONF['empty_section'])
+        self.assertEqual([], conf.get('sockets'))
+        self.assertEqual([], conf.get('plugins'))
 
 
 test_suite = EasyTestSuite(__name__)

--- a/circus/tests/test_config.py
+++ b/circus/tests/test_config.py
@@ -42,7 +42,7 @@ _CONF = {
     'issue651': os.path.join(CONFIG_DIR, 'issue651.ini'),
     'issue665': os.path.join(CONFIG_DIR, 'issue665.ini'),
     'issue680': os.path.join(CONFIG_DIR, 'issue680.ini'),
-    'virtualenv': os.path.join(CONFIG_DIR, 'virtualenv.ini')
+    'virtualenv': os.path.join(CONFIG_DIR, 'virtualenv.ini'),
 }
 
 


### PR DESCRIPTION
Circus startup might otherwise crash, if configuration is modified by an automated script which does not remove empty sections – which can happen if configured by the [puppet-circus](https://github.com/daenney/puppet-circus) module, which uses [puppetlabs-inifile](https://github.com/puppetlabs/puppetlabs-inifile).