### PR TITLE
Cannot specify socket as blocking

### DIFF
--- a/docs/source/for-ops/configuration.rst
+++ b/docs/source/for-ops/configuration.rst
@@ -409,6 +409,9 @@ socket:NAME - as many sections as you want
         If set to True and SO_REUSEPORT is available on target platform, circus
         will create and bind new SO_REUSEPORT socket(s) for every worker it starts
         which is a user of this socket(s).
+    **blocking**
+        If `True`, socket is set to blocking. If `False`, socket is set to non-blocking.
+        (default: False)
 
     **use_papa**
         Set to true to use the :ref:`papa`.


### PR DESCRIPTION
The configuration for sockets support many options, but doesn't support specifying a socket as blocking or non-blocking. Suggest to add support for this as a new boolean field `blocking`.

". For example:
```
[socket:test]
host = 0.0.0.0
port = 8000
blocking = true
```

This creates a blocking socket on port 8000. If the parameter is absent, it will assume the value of "false", in keeping with the current default behaviour.