### PR TITLE
Shorten supervisord.conf example by using the defaults

### DIFF
--- a/docs/source/tutorial/rationale.rst
+++ b/docs/source/tutorial/rationale.rst
@@ -111,8 +111,6 @@ case, the application will be started and restarted in case it crashes ::
     command=npm start
     directory=/home/www/my-server/
     user=www-data
-    autostart=true
-    autorestart=true
     redirect_stderr=True
 
 In Circus, the same configuration is done by::


### PR DESCRIPTION
- `autostart=true` can be removed because [it is the default](https://github.com/Supervisor/supervisor/blob/3.3.0/supervisor/skel/sample.conf#L66).

- `autorestart=true` can also be removed.  The default value of [`autorestart=unexpected`](https://github.com/Supervisor/supervisor/blob/3.3.0/supervisor/skel/sample.conf#L69) is better because the Circus page says the process should be "restarted in case it crashes".  `autorestart=true` would restart unconditionally, including if the process exited with status 0 (success).  The default value of `autorestart=unexpected` will restart the process if it crashes.