### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,8 +20,8 @@ Circus can be used as a library or through the command line.
 
 Links:
 
-- Full Documentation : http://circus.readthedocs.org
-- How to Contribute : http://circus.readthedocs.org/en/latest/contributing/
+- Full Documentation : https://circus.readthedocs.io
+- How to Contribute : https://circus.readthedocs.io/en/latest/contributing/
 - Mailing List : https://groups.yahoo.com/neo/groups/circus-dev/info
 - Repository & Issue Tracker : https://github.com/circus-tent/circus
 - IRC : Freenode, channel #mozilla-circus

--- a/docs/source/man/circus-top.rst
+++ b/docs/source/man/circus-top.rst
@@ -38,4 +38,4 @@ See also
 
 `circus` (1), `circusctl` (1), `circusd` (1), `circusd-stats` (1), `circus-plugin` (1).
 
-Full Documentation is available at http://circus.readthedocs.org
+Full Documentation is available at https://circus.readthedocs.io

--- a/docs/source/man/circusctl.rst
+++ b/docs/source/man/circusctl.rst
@@ -77,4 +77,4 @@ See Also
 
 `circus` (1), `circusd` (1), `circusd-stats` (1), `circus-plugin` (1), `circus-top` (1).
 
-Full Documentation is available at http://circus.readthedocs.org
+Full Documentation is available at https://circus.readthedocs.io

--- a/docs/source/man/circusd-stats.rst
+++ b/docs/source/man/circusd-stats.rst
@@ -49,4 +49,4 @@ See also
 
 `circus` (1), `circusd` (1), `circusctl` (1), `circus-plugin` (1), `circus-top` (1).
 
-Full Documentation is available at http://circus.readthedocs.org
+Full Documentation is available at https://circus.readthedocs.io

--- a/docs/source/man/circusd.rst
+++ b/docs/source/man/circusd.rst
@@ -56,4 +56,4 @@ See also
 
 `circus` (1), `circusctl` (1), `circusd-stats` (1), `circus-plugin` (1), `circus-top` (1).
 
-Full Documentation is available at http://circus.readthedocs.org
+Full Documentation is available at https://circus.readthedocs.io

--- a/docs/source/tutorial/rationale.rst
+++ b/docs/source/tutorial/rationale.rst
@@ -102,7 +102,7 @@ Configuration
 Both systems use an ini-like file as a configuration.
 
 - `Supervisor documentation <http://supervisord.org/configuration.html>`_
-- `Circus documentation <http://circus.readthedocs.org/en/latest/configuration/>`_
+- `Circus documentation <https://circus.readthedocs.io/en/latest/for-ops/configuration/>`_
 
 Here's a small example of running an application with Supervisor. In this
 case, the application will be started and restarted in case it crashes ::

--- a/docs/source/tutorial/step-by-step.rst
+++ b/docs/source/tutorial/step-by-step.rst
@@ -140,4 +140,4 @@ world simply by pointing the application callable.
 
 Chaussette also comes with many backends like Gevent or Meinheld.
 
-Read https://chaussette.readthedocs.org/ for all options.
+Read https://chaussette.readthedocs.io/ for all options.

--- a/docs/source/usecases.rst
+++ b/docs/source/usecases.rst
@@ -118,4 +118,4 @@ the *env* configation option:
     PYTHONPATH = /path/to/parent-of-dproject
     DJANGO_SETTINGS_MODULE=dproject.settings
 
-See http://chaussette.readthedocs.org for more about chaussette.
+See https://chaussette.readthedocs.io for more about chaussette.


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.