### PR TITLE
Fix #997 - reloadconfig concurrency

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -90,3 +90,4 @@ List of contributors:
 - Mike Dunn <mike@eikonomega.com>
 - Yannick PEROUX <yannick.peroux@gmail.com>
 - David Douard <david.douard@logilab.fr>
+- Sergii Mikhtoniuk <mikhtoniuk@gmail.com>

--- a/circus/arbiter.py
+++ b/circus/arbiter.py
@@ -389,7 +389,7 @@ class Arbiter(object):
             if diff == set(['numprocesses']):
                 # if nothing but the number of processes is
                 # changed, just changes this
-                w.set_numprocesses(int(new_watcher_cfg['numprocesses']))
+                yield w.set_numprocesses(int(new_watcher_cfg['numprocesses']))
                 changed = False
             else:
                 changed = len(diff) > 0


### PR DESCRIPTION
Missing yield on `watcher.set_numprocesses` call was causing
this coroutine to run and spawn processes while @synchronized lock
was already released. So this coroutine could overlap with the next
pump of `manage_watchers` and cause a lot more processes to be
spawned than necessary.
