### PR TITLE
Fix #998 - premature shutdown leaking processes

### DIFF
--- a/circus/controller.py
+++ b/circus/controller.py
@@ -175,8 +175,6 @@ class Controller(object):
             if cid is not None:
                 self.stream.flush()
 
-            self.arbiter.stop()
-
     def dispatch(self, job, future=None):
         cid, msg = job
         try:


### PR DESCRIPTION
The `SysHandler` class issues `quit` command when it catches the
`SIGTERM` signal. This command in its turn calls `arbiter.stop()`,
but if you put a breakpoint into this function you will notice
that it's beign called twice, once from `quit` command and once
from this weird place in controller's command dispatch callback.
I digged through history and it looks like leftovers of some old
command refactoring.
