### PR TITLE
Fixing #1001 - non-zero exit code on conflict errors

### DIFF
--- a/circus/controller.py
+++ b/circus/controller.py
@@ -261,6 +261,8 @@ class Controller(object):
         resp['id'] = mid
         resp = json.dumps(resp)
 
+        logger.debug("sending response %s", resp)
+
         try:
             self.stream.send(cid, zmq.SNDMORE)
             self.stream.send(resp)


### PR DESCRIPTION
Making circusctl return non-zero exit code when command resulted
in `staus == "error"`.
