### PR TITLE
Coerce 'max_retry' value to int

### DIFF
--- a/circus/watcher.py
+++ b/circus/watcher.py
@@ -228,7 +228,7 @@ class Watcher(object):
         self.stdout_stream = get_stream(self.stdout_stream_conf)
         self.stderr_stream = get_stream(self.stderr_stream_conf)
         self.stream_redirector = None
-        self.max_retry = max_retry
+        self.max_retry = int(max_retry)
         self._options = options
         self.singleton = singleton
         self.copy_env = copy_env


### PR DESCRIPTION
Coerce `max_retry` value to int so spawn_process() doesn't choke on a INI-sourced override for this value (which arrives as a str). Otherwise, when using the flapping plugin and setting `max_retry` from `circus.ini`, one will get an "unorderable types" exception.