### PR TITLE
Ignore garbage messages from endpoint

### DIFF
--- a/circus/controller.py
+++ b/circus/controller.py
@@ -130,7 +130,12 @@ class Controller(object):
         self.sys_hdl.stop()
 
     def handle_message(self, raw_msg):
-        cid, msg = raw_msg
+        try:
+            cid, msg = raw_msg
+        except:
+            logger.warning("Got unexpected msg %s", str(raw_msg))
+            return
+
         msg = msg.strip()
 
         if not msg:


### PR DESCRIPTION
Fixes #1018.

Catchs any exception related to `raw_msg` processing, logs the offending message and returns without any further processing.

No tests added :disappointed: 

