### PR TITLE
Wait for a child to finish in Watcher.reap_process

### DIFF
--- a/circus/arbiter.py
+++ b/circus/arbiter.py
@@ -4,7 +4,6 @@ import os
 import gc
 from circus.fixed_threading import Thread, get_ident
 import sys
-from time import sleep
 import select
 import socket
 from tornado import gen
@@ -621,10 +620,7 @@ class Arbiter(object):
                         watcher = watchers_pids[pid]
                         watcher.reap_process(pid, status)
                 except OSError as e:
-                    if e.errno == errno.EAGAIN:
-                        sleep(0)
-                        continue
-                    elif e.errno == errno.ECHILD:
+                    if e.errno == errno.ECHILD:
                         # process already reaped
                         return
                     else:

--- a/circus/watcher.py
+++ b/circus/watcher.py
@@ -457,12 +457,13 @@ class Watcher(object):
                     continue
             else:
                 try:
-                    _, status = os.waitpid(pid, os.WNOHANG)
-                except OSError as e:
-                    if e.errno == errno.EAGAIN:
+                    resulting_pid, status = os.waitpid(pid, os.WNOHANG)
+                    if (resulting_pid, status) == (0, 0):
+                        status = None
                         time.sleep(timeout)
                         continue
-                    elif e.errno == errno.ECHILD:
+                except OSError as e:
+                    if e.errno == errno.ECHILD:
                         status = None
                     else:
                         raise


### PR DESCRIPTION
`Watcher.reap_process()` uses `os.waitpid()` with `WNOHANG` flag to get child process status. It had an `OSError` exception handler checking if `errno` equals `EAGAIN`, in which case it would sleep a bit and call `waitpid` again. This mechanism was probably added to handle a case when child process has not died yet, so `waitpid` would block if not for `WNOHANG`.

However, in case a child with such a `pid` is still alive, `os.waitpid()` won't throw an exception, instead it will return a tuple `(0, 0)`, as stated [in the docs](https://docs.python.org/2/library/os.html#os.WNOHANG) (underlying function `waitpid` from `libc` does the same, returning `0` in this case).

As a result, reap_process() failed to correctly check if a child was still alive, causing it to
* before commit https://github.com/circus-tent/circus/commit/7e35727b, busy-wait for a child to stop (or, with gevent-patched `waitpid`, to fall into an endless loop, which, I beleive, is a reason for https://github.com/circus-tent/circus/issues/802)
* in current version, unconditionally succeed after the first call to `waitpid`

In fact, `reap_process()` would always finish immediately despite child's state. This can be a problem, for example, if a child was `SIGKILL`'ed by the Watcher, but has not exited yet, causing https://github.com/circus-tent/circus/issues/1023.

As in https://github.com/circus-tent/circus/issues/1023, if a child is in a disk sleep state, it won't exit after `SIGKILL`. I think the easiest way to get a process hang in disk sleep is to use `sshfs`. One can mount a directory from a VM using `sshfs`.
```bash
sudo sshfs user@192.168.59.3:/tmp /tmp/test-mount -o allow_other -o IdentityFile=id_rsa
```
Now, if we put the VM with address `192.168.59.3` on pause, processes accessing `/tmp/test-mount` will hang in un-interruptible sleep. The following test code can issustrate the problem:
```python
from circus.watcher import Watcher 
from tornado.ioloop import IOLoop
from tornado import gen

watcher = Watcher('test', 'ls', ["/tmp/test-mount/"], graceful_timeout=2.0)

@gen.coroutine
def stop_watcher_after_timeout():
    print 'sleeping'
    yield gen.sleep(0.5)
    print 'stopping watcher'
    yield watcher.stop()
    print 'stopped'

@gen.coroutine
def run():
    yield [watcher.start(), stop_watcher_after_timeout()]
IOLoop.instance().run_sync(run)
print 'done'
```
Result:
```bash
$ python test.py 
sleeping
stopping watcher
stopped
done # watcher finishes quickly, leaving ls running
$ ps aux|grep ls |grep test-mount
asterite  7454  0.0  0.0  16900   936 ?        Ds   02:04   0:00 ls /tmp/test-mount/
```
With this fix, watcher will hang until a process exits (once VM is un-paused).
A similar test can be made for `Arbiter`: https://gist.github.com/asterite3/4e5a2bafdfbea504454b2c1388e93559
