### PR TITLE
Fix #1038 - sort string representation of plugin config

### DIFF
--- a/circus/plugins/__init__.py
+++ b/circus/plugins/__init__.py
@@ -159,7 +159,9 @@ class CircusPlugin(object):
 
 
 def _cfg2str(cfg):
-    return ':::'.join(['%s:%s' % (key, val) for key, val in cfg.items()])
+    return ':::'.join([
+         '%s:%s' % (key, val) for key, val in sorted(cfg.items())
+    ])
 
 
 def _str2cfg(data):


### PR DESCRIPTION
This should fix stalled builds and prevent unnecessary occasional worker restarts - see #1038.

Circus can compare string reprs of config to detect a change (for example, it compares commands and stringified config is a part of a command to launch plugin). Converting to string is done by iterating over the dict, which depends on the order of items in it, which can be different for equal dicts. Sorting items of dict before putting them to string will guarantee equal config strings for equal configs.