### PR TITLE
Add python36

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
   - TOX_ENV=py33
   - TOX_ENV=py34
   - TOX_ENV=py35
+  - TOX_ENV=py36
   - TOX_ENV=docs
   - TOX_ENV=flake8
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 sudo: false
-python: 3.5
+python: 3.6
 addons:
   apt:
     packages:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py26-no-gevent,py27,py27-no-gevent,py33,py34,py35,flake8,docs
+envlist = py26,py26-no-gevent,py27,py27-no-gevent,py33,py34,py35,py36,flake8,docs
 
 [testenv:py26]
 deps =


### PR DESCRIPTION
 @tarekziade @k4nar Hey guys,

I wrote this PR to add python3.6, but also because I suspected that the tests have kinda broken?

For some of the tests I see this error:
```
======================================================================
ERROR: test_inet6 (circus.tests.test_sockets.TestSockets)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/build/circus-tent/circus/circus/tests/test_sockets.py", line 186, in test_inet6
    sock.bind_and_listen()
  File "/home/travis/build/circus-tent/circus/circus/sockets.py", line 210, in bind_and_listen
    self.bind((self.host, self.port))
  File "/usr/lib/python2.7/socket.py", line 224, in meth
    return getattr(self._sock,name)(*args)
error: [Errno 99] Cannot assign requested address
-------------------- >> begin captured logging << --------------------
circus: ERROR: Could not bind ::1:0
--------------------- >> end captured logging << ---------------------
```

And for other tests, `tox` isn't able to find the correct python interpreter.

Any ideas on this?