### PR TITLE
Add support for socket groups, so different sockets can be connected to different watchers

### DIFF
--- a/circus/arbiter.py
+++ b/circus/arbiter.py
@@ -2,6 +2,7 @@ import errno
 import logging
 import os
 import gc
+import operator
 from circus.fixed_threading import Thread, get_ident
 import sys
 import select
@@ -473,6 +474,16 @@ class Arbiter(object):
     def iter_watchers(self, reverse=True):
         return sorted(self.watchers, key=lambda a: a.priority, reverse=reverse)
 
+    def iter_active_watchers(self, fd, reverse=True):
+        a_watchers = []
+        for watcher in self.watchers:
+            wanted_sockets = [name for name, sock in watcher.sockets.items()
+                              if sock.fileno() == fd]
+            if len(set(watcher.sockets).intersection(set(wanted_sockets))) > 0:
+                a_watchers.append(watcher)
+        return sorted(a_watchers, key=operator.attrgetter('priority'),
+                      reverse=reverse)
+
     @debuglog
     def initialize(self):
         # set process title
@@ -647,9 +658,9 @@ class Arbiter(object):
         if need_on_demand:
             sockets = [x.fileno() for x in self.sockets.values()]
             rlist, wlist, xlist = select.select(sockets, [], [], 0)
-            if rlist:
+            for r in rlist:
                 self.socket_event = True
-                self._start_watchers()
+                self._start_watchers(watcher_fd=r)
                 self.socket_event = False
 
     @synchronized("arbiter_reload")
@@ -743,8 +754,10 @@ class Arbiter(object):
         yield self._start_watchers(watcher_iter_func=watcher_iter_func)
 
     @gen.coroutine
-    def _start_watchers(self, watcher_iter_func=None):
-        if watcher_iter_func is None:
+    def _start_watchers(self, watcher_iter_func=None, watcher_fd=None):
+        if watcher_fd is not None:
+            watchers = self.iter_active_watchers(watcher_fd)
+        elif watcher_iter_func is None:
             watchers = self.iter_watchers()
         else:
             watchers = watcher_iter_func()

--- a/circus/sockets.py
+++ b/circus/sockets.py
@@ -37,7 +37,8 @@ class PapaSocketProxy(object):
     def __init__(self, name='', host=None, port=None,
                  family=None, type=None,
                  proto=None, backlog=None, path=None, umask=None, replace=None,
-                 interface=None, so_reuseport=False, blocking=False):
+                 interface=None, so_reuseport=False, blocking=False,
+                 group=None):
         if path is not None:
             if not hasattr(socket, 'AF_UNIX'):
                 raise NotImplementedError("AF_UNIX not supported on this"
@@ -73,6 +74,7 @@ class PapaSocketProxy(object):
         self.so_reuseport = papa_socket.get('so_reuseport', False)
         self._fileno = papa_socket.get('fileno')
         self.use_papa = True
+        self.group = group
         if log_differences:
             differences = []
             if host != self.host:
@@ -122,7 +124,8 @@ class CircusSocket(socket.socket):
     def __init__(self, name='', host='localhost', port=8080,
                  family=socket.AF_INET, type=socket.SOCK_STREAM,
                  proto=0, backlog=2048, path=None, umask=None, replace=False,
-                 interface=None, so_reuseport=False, blocking=False):
+                 interface=None, so_reuseport=False, blocking=False,
+                 group=None):
         if path is not None:
             if not hasattr(socket, 'AF_UNIX'):
                 raise NotImplementedError("AF_UNIX not supported on this"
@@ -138,6 +141,7 @@ class CircusSocket(socket.socket):
         self.umask = umask
         self.replace = replace
         self.use_papa = False
+        self.group = group
 
         if hasattr(socket, 'AF_UNIX') and family == socket.AF_UNIX:
             self.host = self.port = None
@@ -246,7 +250,8 @@ class CircusSocket(socket.socket):
                   'so_reuseport': to_bool(config.get('so_reuseport')),
                   'umask': int(config.get('umask', 8)),
                   'replace': config.get('replace'),
-                  'blocking': to_bool(config.get('blocking'))}
+                  'blocking': to_bool(config.get('blocking')),
+                  'group': config.get('group')}
         use_papa = to_bool(config.get('use_papa')) and papa is not None
         proto_name = config.get('proto')
         if proto_name is not None:


### PR DESCRIPTION
This is useful if you use circus for socket activation of multiple daemons,
connected to different sockets.