### PR TITLE
circus/tests: rename async argument of _create_circus() to use_async

### DIFF
--- a/circus/tests/support.py
+++ b/circus/tests/support.py
@@ -217,7 +217,7 @@ class TestCircus(AsyncTestCase):
                       stdout_stream=None, debug=True, **kw):
         testfile, arbiter = self._create_circus(
             cmd, stdout_stream=stdout_stream,
-            debug=debug, async=True, **kw)
+            debug=debug, use_async=True, **kw)
         self.test_file = testfile
         self.arbiter = arbiter
         self.arbiters.append(arbiter)
@@ -265,7 +265,7 @@ class TestCircus(AsyncTestCase):
 
     @classmethod
     def _create_circus(cls, callable_path, plugins=None, stats=False,
-                       async=False, arbiter_kw=None, **kw):
+                       use_async=False, arbiter_kw=None, **kw):
         fd, testfile = mkstemp()
         os.close(fd)
         wdir = os.path.dirname(os.path.dirname(os.path.dirname(
@@ -292,7 +292,7 @@ class TestCircus(AsyncTestCase):
             arbiter_kw['stats_endpoint'] = "tcp://127.0.0.1:%d" % _gp()
             arbiter_kw['statsd_close_outputs'] = not debug
 
-        if async:
+        if use_async:
             arbiter_kw['background'] = False
             arbiter_kw['loop'] = get_ioloop()
         else:

--- a/circus/tests/test_client.py
+++ b/circus/tests/test_client.py
@@ -90,7 +90,7 @@ class TestWithHook(TestCircus):
         self.stream = QueueStream()
         self.errstream = QueueStream()
         dummy_process = 'circus.tests.support.run_process'
-        return self._create_circus(dummy_process, async=True,
+        return self._create_circus(dummy_process, use_async=True,
                                    stdout_stream={'stream': self.stream},
                                    stderr_stream={'stream': self.errstream},
                                    hooks=hooks)

--- a/circus/tests/test_watcher.py
+++ b/circus/tests/test_watcher.py
@@ -376,7 +376,7 @@ class TestWatcherHooks(TestCircus):
         return self._create_circus(dummy_process,
                                    stdout_stream=stdout_stream,
                                    stderr_stream=stderr_stream,
-                                   hooks=hooks, debug=True, async=True)
+                                   hooks=hooks, debug=True, use_async=True)
 
     @tornado.gen.coroutine
     def _stop(self):
@@ -601,7 +601,7 @@ class RespawnTest(TestCircus):
     def test_not_respawning(self):
         oneshot_process = 'circus.tests.test_watcher.oneshot_process'
         testfile, arbiter = self._create_circus(oneshot_process,
-                                                respawn=False, async=True)
+                                                respawn=False, use_async=True)
         yield arbiter.start()
         watcher = arbiter.watchers[-1]
         try:


### PR DESCRIPTION
In Python 3.7.0, 'async' is now a reserved keyword of the language, so
it cannot be used as an method argument name. When used, it causes the
following byte-compilation failure:

Traceback (most recent call last):
  File "/home/thomas/projets/buildroot/output/host/lib/python3.7/py_compile.py", line 136, in compile
    _optimize=optimize)
  File "<frozen importlib._bootstrap_external>", line 763, in source_to_code
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "usr/lib/python3.7/site-packages/circus/tests/support.py", line 210
    debug=debug, async=True, **kw)
                     ^
SyntaxError: invalid syntax

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>