### PR TITLE
allow stop_signal to be an integer in circus configuration file

### DIFF
--- a/circus/config.py
+++ b/circus/config.py
@@ -27,6 +27,7 @@ def watcher_defaults():
         'warmup_delay': 0,
         'executable': None,
         'working_dir': None,
+        'on_demand': False,
         'shell': False,
         'uid': None,
         'gid': None,
@@ -227,7 +228,7 @@ def get_config(config_file):
                     watcher['executable'] = dget(section, 'executable', None,
                                                  str)
                 # default bool to False
-                elif opt in ('shell', 'send_hup', 'stop_children',
+                elif opt in ('on_demand', 'shell', 'send_hup', 'stop_children',
                              'close_child_stderr', 'use_sockets', 'singleton',
                              'copy_env', 'copy_path', 'close_child_stdout'):
                     watcher[opt] = dget(section, opt, False, bool)

--- a/circus/util.py
+++ b/circus/util.py
@@ -321,8 +321,11 @@ def to_signum(signum):
         'SIGKILL' - signal names with SIG prefix
         'SIGRTMIN+1' - signal names with offsets
     """
-    if isinstance(signum, int):
-        return signum
+    try:
+        val = int(signum)
+        return val
+    except ValueError:
+        pass
 
     m = re.match(r'(\w+)(\+(\d+))?', signum)
     if m:


### PR DESCRIPTION
signum is type 'str' when passed to `def to_signum(signum)`.  If you enter an integer for the stop_signal in a circus ini file, the value falls through to the regular expression matching, and will fail with a ValueError.  The patch will attempt to cast the 'str' to an 'int', if it fails it will then pass the value through to the regular expression.