### PR TITLE
Swap the order of terminating workers: from worker first to childs first

### DIFF
--- a/circus/watcher.py
+++ b/circus/watcher.py
@@ -708,24 +708,22 @@ class Watcher(object):
             # getting the process children
             children = process.children(recursive=recursive)
 
+            # now sending the same signal to all the children
+            for child_pid in children:
+                try:
+                    process.send_signal_child(child_pid, signum)
+                    self.notify_event("kill", {"process_pid": child_pid,
+                                      "time": time.time()})
+                except NoSuchProcess:
+                    # already dead !
+                    pass
+
             # sending the signal to the process itself
             self.send_signal(process.pid, signum)
             self.notify_event("kill", {"process_pid": process.pid,
                                        "time": time.time()})
         except NoSuchProcess:
-            # already dead !
-            if children is None:
-                return
-
-        # now sending the same signal to all the children
-        for child_pid in children:
-            try:
-                process.send_signal_child(child_pid, signum)
-                self.notify_event("kill", {"process_pid": child_pid,
-                                  "time": time.time()})
-            except NoSuchProcess:
-                # already dead !
-                pass
+            pass
 
     @gen.coroutine
     @util.debuglog


### PR DESCRIPTION
Currently when circus [terminating a worker](https://github.com/circus-tent/circus/blob/master/circus/watcher.py#L701-L728), it sends signal to worker, and then to each child process.

But according to [`send_signal_child `](https://github.com/circus-tent/circus/blob/master/circus/process.py#L539-L546), when sending signals to a child, psutil's [`Process.children()`](https://github.com/circus-tent/circus/blob/master/circus/process.py#L45) is used to live query the children of the parent worker process, which is signaled death before. This is the cause that child process don't receive signal.

A workaround is changing the order, and send signal to childs first. 

May be a fix for #1044 