### PR TITLE
'circusctl options <watcher>' command -- output modification

### DIFF
--- a/circus/watcher.py
+++ b/circus/watcher.py
@@ -1167,6 +1167,9 @@ class Watcher(object):
     @util.debuglog
     def options(self, *args):
         options = []
+        for rlimit in self.rlimits:
+            rlimit_name = "rlimit_{0}".format(rlimit)
+            options.append((rlimit_name, self.rlimits[rlimit]))
         for hook in self.hooks:
             hook_name = "hooks.{0}".format(hook)
             hook_module = "{0}.{1}".format(


### PR DESCRIPTION
This patch changes the output of the:

'circusctl options <watcher>'

to match the information in the  [watcher:<name>] section of the configuration file.  You can now view any rlimit_*, and std[out|err]_stream options.  The dict information from std[out|err]_stream_conf has been removed from the output, replace with std[out|err]_stream.* (as it would appear in the configuration file)