### PR TITLE
Fix Travis CI builds & drop Python 2.6 support

### DIFF
--- a/.coveralls.sh
+++ b/.coveralls.sh
@@ -1,5 +1,0 @@
-if [ "$TOX_ENV" = "py27" ]
-then
-   pip install coveralls
-   coveralls
-fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,10 +46,6 @@ jobs:
       env: TOX_ENV=py27
     - python: 2.7
       env: TOX_ENV=py27-no-gevent
-    - python: 2.6
-      env: TOX_ENV=py26
-    - python: 2.6
-      env: TOX_ENV=py26-no-gevent
 
 script:
     - tox -v -e $TOX_ENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,14 +33,15 @@ jobs:
       env: TOX_ENV=py34
     - python: 2.7
       env: TOX_ENV=py27
-    - python: 2.7
-      env: TOX_ENV=py27-no-gevent
 
 script:
     - tox -v -e $TOX_ENV
 
 install:
-    - pip install tox
+    - pip install tox coveralls
+
+after_success:
+    - coveralls
 
 notifications:
     email: tarek@mozilla.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,14 @@
+dist: xenial
+sudo: required
+
 language: python
-sudo: false
+
 addons:
   apt:
     packages:
       - libev-dev
       - libevent-dev
 
-before_install:
-  # Try https://github.com/travis-ci/travis-ci/issues/8363#issuecomment-327857631
-  # to workaround Travis having broken Python3.5, and flaky 3.4
-  #
-  #
-  - pyenv global ${TRAVIS_PYTHON_VERSION}
-  - >
-    if [[ $TRAVIS_PYTHON_VERSION = "3.5" ]]; then deactivate; sudo rm -rf /opt/python /home/travis/virtualenv; sudo add-apt-repository -y ppa:deadsnakes/ppa;
-    sudo apt-get update; sudo apt-get install -y python3.5 python3.5-dev; pyenv rehash; pyenv global system; pip install -U virtualenv pip;
-    virtualenv --python=/usr/bin/python3.5 --no-site-packages ~/working_venv; source ~/working_venv/bin/activate;
-    python --version; which python; pip --version; fi
 before_script:
   # Add an IPv6 config - see the corresponding Travis issue
   # https://github.com/travis-ci/travis-ci/issues/8361
@@ -29,9 +21,6 @@ jobs:
   include:
     - python: 3.7
       env: TOX_ENV=py37
-      # cf https://github.com/travis-ci/travis-ci/issues/9069#issuecomment-425720905
-      sudo: required
-      dist: xenial
     - python: 3.6
       env: TOX_ENV=docs
     - python: 3.6

--- a/circus/circusctl.py
+++ b/circus/circusctl.py
@@ -54,7 +54,7 @@ def prettify(jsonobj, prettify=True):
         try:
             lexer = get_lexer_for_mimetype("application/json")
             return pygments.highlight(json_str, lexer, TerminalFormatter())
-        except:
+        except:  # noqa: E722
             pass
 
     return json_str

--- a/circus/commands/restart.py
+++ b/circus/commands/restart.py
@@ -48,6 +48,7 @@ def execute_watcher_start_stop_restart(command, arbiter, props,
     else:
         return arbiter_function()
 
+
 match_options = ('match', 'match', 'glob',
                  "Watcher name matching method (simple, glob or regex)")
 

--- a/circus/controller.py
+++ b/circus/controller.py
@@ -229,7 +229,7 @@ class Controller(object):
         except OSError as e:
             return self.send_error(mid, cid, msg, str(e), cast=cast,
                                    errno=errors.OS_ERROR)
-        except:
+        except:  # noqa: E722
             exctype, value = sys.exc_info()[:2]
             tb = traceback.format_exc()
             reason = "command %r: %s" % (msg, value)

--- a/circus/pidfile.py
+++ b/circus/pidfile.py
@@ -62,7 +62,7 @@ class Pidfile(object):
 
             if pid1 == self.pid:
                 os.unlink(self.fname)
-        except:
+        except:  # noqa: E722
             pass
 
     def validate(self):

--- a/circus/stream/__init__.py
+++ b/circus/stream/__init__.py
@@ -9,9 +9,9 @@ except ImportError:
 
 from circus.util import resolve_name
 from circus.stream.file_stream import FileStream
-from circus.stream.file_stream import WatchedFileStream  # flake8: noqa
-from circus.stream.file_stream import TimedRotatingFileStream  # flake8: noqa
-from circus.stream.redirector import Redirector
+from circus.stream.file_stream import WatchedFileStream  # noqa: F401
+from circus.stream.file_stream import TimedRotatingFileStream  # noqa: F401
+from circus.stream.redirector import Redirector  # noqa: F401
 from circus.py3compat import s
 
 
@@ -125,7 +125,7 @@ def get_stream(conf, reload=False):
         # we can have 'stream' or 'class' or 'filename'
         if 'class' in conf:
             class_name = conf.pop('class')
-            if not "." in class_name:
+            if "." not in class_name:
                 cls = globals()[class_name]
                 inst = cls(**conf)
             else:

--- a/circus/tests/generic.py
+++ b/circus/tests/generic.py
@@ -45,5 +45,5 @@ if __name__ == '__main__':
             sys.exit(callback(test_file))
         else:
             sys.exit(callback())
-    except:
+    except:  # noqa: E722
         sys.exit(1)

--- a/circus/tests/support.py
+++ b/circus/tests/support.py
@@ -11,7 +11,6 @@ import functools
 import multiprocessing
 import socket
 import sysconfig
-DEBUG = sysconfig.get_config_var('Py_DEBUG') == 1
 
 try:
     from unittest import skip, skipIf, TestCase, TestSuite, findTestCases
@@ -30,6 +29,8 @@ from circus.util import DEFAULT_ENDPOINT_DEALER, DEFAULT_ENDPOINT_SUB
 from circus.util import tornado_sleep, ConflictError
 from circus.util import IS_WINDOWS
 from circus.watcher import Watcher
+
+DEBUG = sysconfig.get_config_var('Py_DEBUG') == 1
 
 ioloop.install()
 if 'ASYNC_TEST_TIMEOUT' not in os.environ:

--- a/circus/tests/support.py
+++ b/circus/tests/support.py
@@ -10,13 +10,8 @@ import shutil
 import functools
 import multiprocessing
 import socket
-try:
-    import sysconfig
-    DEBUG = sysconfig.get_config_var('Py_DEBUG') == 1
-except ImportError:
-    # py2.6, we don't really care about that flage here
-    # since no one will run Python --with-pydebug in 2.6
-    DEBUG = 0
+import sysconfig
+DEBUG = sysconfig.get_config_var('Py_DEBUG') == 1
 
 try:
     from unittest import skip, skipIf, TestCase, TestSuite, findTestCases

--- a/circus/tests/test_arbiter.py
+++ b/circus/tests/test_arbiter.py
@@ -709,4 +709,5 @@ class TestCircusWeb(TestCircus):
         finally:
             yield arbiter.stop()
 
+
 test_suite = EasyTestSuite(__name__)

--- a/circus/tests/test_circusctl.py
+++ b/circus/tests/test_circusctl.py
@@ -196,4 +196,5 @@ class CLITest(TestCircus):
         self.assertEqual(prompt[3], "Documented commands (type help <topic>):")
         yield self.stop_arbiter()
 
+
 test_suite = EasyTestSuite(__name__)

--- a/circus/tests/test_circusd.py
+++ b/circus/tests/test_circusd.py
@@ -119,4 +119,5 @@ class TestCircusd(TestCase):
         main()
         self.assertFalse(os.path.exists(pid_file))
 
+
 test_suite = EasyTestSuite(__name__)

--- a/circus/tests/test_command_list.py
+++ b/circus/tests/test_command_list.py
@@ -19,4 +19,5 @@ class ListCommandTest(TestCircus):
         cmd = List()
         self.assertTrue("error" in cmd.console_msg({'foo': 'bar'}))
 
+
 test_suite = EasyTestSuite(__name__)

--- a/circus/tests/test_command_quit.py
+++ b/circus/tests/test_command_quit.py
@@ -12,4 +12,5 @@ class QuitTest(TestCircus):
         cmd.execute(arbiter, props)
         self.assertEqual(len(arbiter.watchers), 0)
 
+
 test_suite = EasyTestSuite(__name__)

--- a/circus/tests/test_command_set.py
+++ b/circus/tests/test_command_set.py
@@ -64,4 +64,5 @@ class SetTest(TestCircus):
         watcher = arbiter.watchers[0]
         self.assertEqual(watcher.options['args'], '--arg1 1 --arg2 2')
 
+
 test_suite = EasyTestSuite(__name__)

--- a/circus/tests/test_command_signal.py
+++ b/circus/tests/test_command_signal.py
@@ -250,6 +250,7 @@ class SignalRecursiveCommandTest(TestCircus):
 
         yield self.stop_arbiter()
 
+
 test_suite = EasyTestSuite(__name__)
 
 if __name__ == '__main__':

--- a/circus/tests/test_command_stats.py
+++ b/circus/tests/test_command_stats.py
@@ -73,4 +73,5 @@ class StatsCommandTest(TestCircus):
         props = {'name': 'meh', 'process': 'meh'}
         self.assertRaises(MessageError, cmd.execute, arbiter, props)
 
+
 test_suite = EasyTestSuite(__name__)

--- a/circus/tests/test_config.py
+++ b/circus/tests/test_config.py
@@ -192,7 +192,7 @@ class TestConfig(TestCase):
         """https://github.com/circus-tent/circus/pull/473"""
         try:
             get_config(_CONF['empty_include'])
-        except:
+        except:  # noqa: E722
             self.fail('Non-existent includes should not raise')
         self.assertTrue(mock_logger_warn.called)
 

--- a/circus/tests/test_convert_option.py
+++ b/circus/tests/test_convert_option.py
@@ -46,4 +46,5 @@ class TestConvertOption(TestCase):
         self.assertRaises(ArgumentError, convert_option, 'hooks',
                           'before_start:one:two')
 
+
 test_suite = EasyTestSuite(__name__)

--- a/circus/tests/test_logging.py
+++ b/circus/tests/test_logging.py
@@ -109,6 +109,7 @@ def run_circusd(options=(), config=(), log_capture_path="log.txt",
             # use (lock).
             pass
 
+
 EXAMPLE_YAML = """\
 version: 1
 disable_existing_loggers: false
@@ -261,5 +262,6 @@ class TestLoggingConfig(TestCase):
             log_capture_path="log_ini_opt.txt",
             additional_files={"logging.ini": logging_dictconfig_to_ini(config)}
         )
+
 
 test_suite = EasyTestSuite(__name__)

--- a/circus/tests/test_papa_stream.py
+++ b/circus/tests/test_papa_stream.py
@@ -23,7 +23,7 @@ def run_process(testfile, *args, **kw):
         with open(testfile, 'a+') as f:
             f.write('START')
         time.sleep(1.)
-    except:
+    except:  # noqa: E722
         return 1
 
 

--- a/circus/tests/test_pidfile.py
+++ b/circus/tests/test_pidfile.py
@@ -80,4 +80,5 @@ class TestPidfile(TestCase):
         except Exception as e:
             self.fail(str(e))
 
+
 test_suite = EasyTestSuite(__name__)

--- a/circus/tests/test_plugin_command_reloader.py
+++ b/circus/tests/test_plugin_command_reloader.py
@@ -89,4 +89,5 @@ class TestCommandReloader(TestCircus):
         plugin = self.make_plugin(CommandReloader, active=True)
         plugin.handle_recv('whatever')
 
+
 test_suite = EasyTestSuite(__name__)

--- a/circus/tests/test_plugin_flapping.py
+++ b/circus/tests/test_plugin_flapping.py
@@ -72,4 +72,5 @@ class TestFlapping(TestCircus):
         cast_mock.assert_called_with("stop", name="test")
         self.assertTrue(timer_mock.called)
 
+
 test_suite = EasyTestSuite(__name__)

--- a/circus/tests/test_plugin_resource_watcher.py
+++ b/circus/tests/test_plugin_resource_watcher.py
@@ -157,4 +157,5 @@ class TestResourceWatcher(TestCircus):
                            '_resource_watcher.test.under_cpu')
         yield self.stop_arbiter()
 
+
 test_suite = EasyTestSuite(__name__)

--- a/circus/tests/test_plugin_watchdog.py
+++ b/circus/tests/test_plugin_watchdog.py
@@ -70,4 +70,5 @@ class TestPluginWatchDog(TestCircus):
         self.assertEqual(len(pid_status), 0, pid_status)
         yield self.stop_arbiter()
 
+
 test_suite = EasyTestSuite(__name__)

--- a/circus/tests/test_reloadconfig.py
+++ b/circus/tests/test_reloadconfig.py
@@ -169,4 +169,5 @@ class TestConfig(tornado.testing.AsyncTestCase):
         yield a.reload_from_config(_CONF['reload_statsd'])
         self.assertEqual(statsd, a.get_watcher('circusd-stats'))
 
+
 test_suite = EasyTestSuite(__name__)

--- a/circus/tests/test_runner.py
+++ b/circus/tests/test_runner.py
@@ -17,4 +17,5 @@ class TestRunner(TestCircus):
         self.assertTrue(res)
         yield self.stop_arbiter()
 
+
 test_suite = EasyTestSuite(__name__)

--- a/circus/tests/test_sighandler.py
+++ b/circus/tests/test_sighandler.py
@@ -20,4 +20,5 @@ class TestSigHandler(TestCircus):
         res = yield async_poll_for(self.test_file, 'QUIT')
         self.assertTrue(res)
 
+
 test_suite = EasyTestSuite(__name__)

--- a/circus/tests/test_stats_client.py
+++ b/circus/tests/test_stats_client.py
@@ -22,7 +22,7 @@ def run_process(*args, **kw):
                                                       os.getpid(), i))
             sys.stderr.flush()
             time.sleep(.25)
-    except:
+    except:  # noqa: E722
         return 1
 
 
@@ -88,5 +88,6 @@ class TestStatsClient(TestCircus):
             self.assertTrue(watcher in ('test', 'circusd-stats', 'circus'),
                             watcher)
         yield self.stop_arbiter()
+
 
 test_suite = EasyTestSuite(__name__)

--- a/circus/tests/test_stats_collector.py
+++ b/circus/tests/test_stats_collector.py
@@ -194,4 +194,5 @@ class TestCollector(TestCase):
         self.assertTrue(stat['fd'] in self.fds)
         self.assertTrue(stat['reads'] > 1)
 
+
 test_suite = EasyTestSuite(__name__)

--- a/circus/tests/test_stats_publisher.py
+++ b/circus/tests/test_stats_publisher.py
@@ -36,4 +36,5 @@ class TestStatsPublisher(TestCase):
         stat = {'subtopic': 1, 'foo': 'bar'}
         publisher.publish('foobar', stat)
 
+
 test_suite = EasyTestSuite(__name__)

--- a/circus/tests/test_stats_streamer.py
+++ b/circus/tests/test_stats_streamer.py
@@ -99,4 +99,5 @@ class TestStatsStreamer(TestCircus):
         streamer.remove_pid('foobar', 1235)
         self.assertTrue(streamer._callbacks['foobar'].stop.called)
 
+
 test_suite = EasyTestSuite(__name__)

--- a/circus/tests/test_stream.py
+++ b/circus/tests/test_stream.py
@@ -25,7 +25,7 @@ def run_process(testfile, *args, **kw):
         with open(testfile, 'a+') as f:
             f.write('START')
         time.sleep(1.)
-    except:
+    except:  # noqa: E722
         return 1
 
 

--- a/circus/tests/test_umask.py
+++ b/circus/tests/test_umask.py
@@ -130,6 +130,7 @@ class UmaskTest(TestCircus):
         mode = oct(os.stat(self.test_file).st_mode)[-3:]
         self.assertEqual(mode, '777')
 
+
 test_suite = EasyTestSuite(__name__)
 
 if __name__ == '__main__':

--- a/circus/tests/test_util.py
+++ b/circus/tests/test_util.py
@@ -309,4 +309,5 @@ class TestUtil(TestCase):
         finally:
             util.os.stat = _old_os_stat
 
+
 test_suite = EasyTestSuite(__name__)

--- a/circus/tests/test_watcher.py
+++ b/circus/tests/test_watcher.py
@@ -671,4 +671,5 @@ class RespawnTest(TestCircus):
         # And be sure we don't spawn new processes in the meantime.
         self.assertFalse(watcher.spawn_processes.called)
 
+
 test_suite = EasyTestSuite(__name__)

--- a/circus/tests/venv/lib/python2.6/orig-prefix.txt
+++ b/circus/tests/venv/lib/python2.6/orig-prefix.txt
@@ -1,1 +1,0 @@
-/System/Library/Frameworks/Python.framework/Versions/2.6

--- a/circus/tests/venv/lib/python2.6/site-packages/easy-install.pth
+++ b/circus/tests/venv/lib/python2.6/site-packages/easy-install.pth
@@ -1,3 +1,0 @@
-import sys; sys.__plen = len(sys.path)
-./pip-7.7-py2.6.egg
-import sys; new=sys.path[sys.__plen:]; del sys.path[sys.__plen:]; p=getattr(sys,'__egginsert',0); sys.path[p:p]=new; sys.__egginsert = p+len(new)

--- a/circus/util.py
+++ b/circus/util.py
@@ -790,10 +790,7 @@ class StrictConfigParser(ConfigParser):
                     raise MissingSectionHeaderError(fpname, lineno, line)
                 # an option line?
                 else:
-                    try:
-                        mo = self._optcre.match(line)   # 2.7
-                    except AttributeError:
-                        mo = self.OPTCRE.match(line)    # 2.6
+                    mo = self._optcre.match(line)   # 2.7
                     if mo:
                         optname, vi, optval = mo.group('option', 'vi', 'value')
                         self.optionxform = text_type

--- a/circus/util.py
+++ b/circus/util.py
@@ -293,6 +293,7 @@ def get_info(process=None, interval=0, with_childs=False):
 
     return info
 
+
 TRUTHY_STRINGS = ('yes', 'true', 'on', '1')
 FALSY_STRINGS = ('no', 'false', 'off', '0')
 
@@ -618,7 +619,7 @@ def resolve_name(import_name, silent=False, reload=False):
             raise_with_tb(ImportStringError(import_name, e))
 
 
-_SECTION_NAME = '\w\.\-'
+_SECTION_NAME = r'\w\.\-'
 _PATTERN1 = r'\$\(%%s\.([%s]+)\)' % _SECTION_NAME
 _PATTERN2 = r'\(\(%%s\.([%s]+)\)\)' % _SECTION_NAME
 _CIRCUS_VAR = re.compile(_PATTERN1 % 'circus' + '|' +

--- a/docs/source/for-ops/index.rst
+++ b/docs/source/for-ops/index.rst
@@ -13,7 +13,7 @@ The first step to manage a Circus daemon is to write its configuration file.
 See :ref:`configuration`. If you are deploying a web stack, have a look at
 :ref:`sockets`.
 
-Circus can be deployed using Python 2.6, 2.7, 3.2 or 3.3 - most deployments
+Circus can be deployed using Python 2.7, 3.2 or 3.3 - most deployments
 out there are done in 2.7. To learn how to deploy Circus, check out
 :ref:`deployment`.
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -36,7 +36,7 @@ More on Requirements
 
 Circus works with:
 
-- Python 2.6, 2.7, 3.2 or 3.3
+- Python 2.7, 3.2 or 3.3
 - zeromq >= 2.1.10 
     - The version of zeromq supported is ultimately determined by what version of `pyzmq <https://github.com/zeromq/pyzmq>`_ is installed by pip during circus installation.
     - Their current release supports 2.x (limited), 3.x, and 4.x ZeroMQ versions.

--- a/docs/source/tutorial/step-by-step.rst
+++ b/docs/source/tutorial/step-by-step.rst
@@ -13,7 +13,7 @@ We're going to supervise a WSGI application.
 Installation
 ------------
 
-Circus is tested on Mac OS X and Linux with the latest Python 2.6, 2.7,
+Circus is tested on Mac OS X and Linux with the latest Python 2.7,
 3.2 and 3.3.  To run a full Circus, you will also need **libzmq**,
 **libevent** & **virtualenv**.
 

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@ import sys
 from setuptools import setup, find_packages
 from circus import __version__
 
-if not hasattr(sys, 'version_info') or sys.version_info < (2, 6, 0, 'final'):
-    raise SystemExit("Circus requires Python 2.6 or higher.")
+if not hasattr(sys, 'version_info') or sys.version_info < (2, 7, 0, 'final'):
+    raise SystemExit("Circus requires Python 2.7 or higher.")
 
 
 install_requires = ['psutil', 'pyzmq>=13.1.0,<17.0', 'tornado>=3.0,<5.0', 'six']
@@ -30,7 +30,6 @@ setup(name='circus',
       classifiers=[
           "Programming Language :: Python",
           "Programming Language :: Python :: 2",
-          "Programming Language :: Python :: 2.6",
           "Programming Language :: Python :: 2.7",
           "Programming Language :: Python :: 3",
           "Programming Language :: Python :: 3.4",

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,5 @@
 [tox]
-envlist = py26,py26-no-gevent,py27,py27-no-gevent,py34,py35,py36,py37,flake8,docs
-
-[testenv:py26]
-deps =
-    {[testenv]deps}
-    gevent<1.2
-    unittest2
-
-[testenv:py26-no-gevent]
-deps =
-    {[testenv]deps}
-    unittest2
+envlist = py27,py27-no-gevent,py34,py35,py36,py37,flake8,docs
 
 [testenv:py27]
 passenv = PWD TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py27-no-gevent,py34,py35,py36,py37,flake8,docs
+envlist = py27,py34,py35,py36,py37,flake8,docs
 
 [testenv:py27]
 passenv = PWD TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
@@ -8,13 +8,11 @@ deps =
     {[testenv]deps}
     nose-cov
     coverage
-    coveralls
     gevent
     circus-web
 
 commands =
     nosetests -vs --with-coverage --cover-package=circus circus/tests
-    coveralls
 
 [testenv]
 passenv = PWD


### PR DESCRIPTION
While addressing issue #1099 I found that the CI builds on Travis were severely broken. I took the liberty to fix them which consisted of moving to Xenial to get the required python versions and addressing various flake8 messages. I dropped 2.6 because it is difficult to install and it has been EOL for over 5 years.