### PR TITLE
Update the `pyzmq` dependency

### DIFF
--- a/circus/arbiter.py
+++ b/circus/arbiter.py
@@ -10,7 +10,7 @@ import socket
 from tornado import gen
 
 import zmq
-from zmq.eventloop import ioloop
+from tornado import ioloop
 
 from circus.controller import Controller
 from circus.exc import AlreadyExist
@@ -242,7 +242,6 @@ class Arbiter(object):
     def _init_context(self, context):
         self.context = context or zmq.Context.instance()
         if self.loop is None:
-            ioloop.install()
             self.loop = ioloop.IOLoop.instance()
         self.ctrl = Controller(self.endpoint, self.multicast_endpoint,
                                self.context, self.loop, self, self.check_delay,

--- a/circus/controller.py
+++ b/circus/controller.py
@@ -12,7 +12,8 @@ except ImportError:
 
 import zmq
 import zmq.utils.jsonapi as json
-from zmq.eventloop import ioloop, zmqstream
+from tornado import ioloop
+from zmq.eventloop import zmqstream
 from tornado.concurrent import Future
 
 from circus.util import create_udp_socket

--- a/circus/plugins/__init__.py
+++ b/circus/plugins/__init__.py
@@ -7,7 +7,8 @@ import argparse
 
 import zmq
 import zmq.utils.jsonapi as json
-from zmq.eventloop import ioloop, zmqstream
+from tornado import ioloop
+from zmq.eventloop import zmqstream
 
 from circus import logger, __version__
 from circus.client import make_message, cast_message

--- a/circus/plugins/command_reloader.py
+++ b/circus/plugins/command_reloader.py
@@ -2,7 +2,7 @@ import os
 
 from circus.plugins import CircusPlugin
 from circus import logger
-from zmq.eventloop import ioloop
+from tornado import ioloop
 
 
 class CommandReloader(CircusPlugin):

--- a/circus/plugins/statsd.py
+++ b/circus/plugins/statsd.py
@@ -1,6 +1,6 @@
 import socket
 
-from zmq.eventloop import ioloop
+from tornado import ioloop
 
 from circus.plugins import CircusPlugin
 from circus.util import human2bytes

--- a/circus/plugins/watchdog.py
+++ b/circus/plugins/watchdog.py
@@ -2,7 +2,7 @@ import re
 import socket
 import time
 
-from zmq.eventloop import ioloop
+from tornado import ioloop
 from circus.plugins import CircusPlugin
 from circus import logger
 from circus import util

--- a/circus/stats/collector.py
+++ b/circus/stats/collector.py
@@ -5,7 +5,7 @@ import socket
 
 from circus import util
 from circus import logger
-from zmq.eventloop import ioloop
+from tornado import ioloop
 
 
 class BaseStatsCollector(ioloop.PeriodicCallback):

--- a/circus/stats/streamer.py
+++ b/circus/stats/streamer.py
@@ -6,7 +6,8 @@ import socket
 
 import zmq
 import zmq.utils.jsonapi as json
-from zmq.eventloop import ioloop, zmqstream
+from tornado import ioloop
+from zmq.eventloop import zmqstream
 
 from circus.commands import get_commands
 from circus.client import CircusClient

--- a/circus/stream/papa_redirector.py
+++ b/circus/stream/papa_redirector.py
@@ -1,4 +1,4 @@
-from zmq.eventloop import ioloop
+from tornado import ioloop
 from circus.stream import Redirector
 
 

--- a/circus/stream/redirector.py
+++ b/circus/stream/redirector.py
@@ -2,7 +2,7 @@ import errno
 import os
 import sys
 
-from zmq.eventloop import ioloop
+from tornado import ioloop
 
 
 class Redirector(object):

--- a/circus/tests/support.py
+++ b/circus/tests/support.py
@@ -19,7 +19,6 @@ except ImportError:
     from unittest2 import findTestCases  # NOQA
 
 from tornado.testing import AsyncTestCase
-from zmq.eventloop import ioloop
 import mock
 import tornado
 
@@ -32,7 +31,6 @@ from circus.watcher import Watcher
 
 DEBUG = sysconfig.get_config_var('Py_DEBUG') == 1
 
-ioloop.install()
 if 'ASYNC_TEST_TIMEOUT' not in os.environ:
     os.environ['ASYNC_TEST_TIMEOUT'] = '30'
 

--- a/circus/tests/support.py
+++ b/circus/tests/support.py
@@ -55,68 +55,7 @@ SLEEP = PYTHON + " -c 'import time;time.sleep(%d)'"
 
 
 def get_ioloop():
-    from zmq.eventloop.ioloop import ZMQPoller
-    from zmq.eventloop.ioloop import ZMQError, ETERM
-    from tornado.ioloop import PollIOLoop
-
-    class DebugPoller(ZMQPoller):
-        def __init__(self):
-            super(DebugPoller, self).__init__()
-            self._fds = []
-
-        def register(self, fd, events):
-            if fd not in self._fds:
-                self._fds.append(fd)
-            return self._poller.register(fd, self._map_events(events))
-
-        def modify(self, fd, events):
-            if fd not in self._fds:
-                self._fds.append(fd)
-            return self._poller.modify(fd, self._map_events(events))
-
-        def unregister(self, fd):
-            if fd in self._fds:
-                self._fds.remove(fd)
-            return self._poller.unregister(fd)
-
-        def poll(self, timeout):
-            """
-            #737 - For some reason the poller issues events with
-            unexistant FDs, usually with big ints. We have not found yet the
-            reason of this
-            behavior that happens only during the tests. But by filtering out
-            those events, everything works fine.
-
-            """
-            z_events = self._poller.poll(1000*timeout)
-            return [(fd, self._remap_events(evt)) for fd, evt in z_events
-                    if fd in self._fds]
-
-    class DebugLoop(PollIOLoop):
-        def initialize(self, **kwargs):
-            PollIOLoop.initialize(self, impl=DebugPoller(), **kwargs)
-
-        def handle_callback_exception(self, callback):
-            exc_type, exc_value, tb = sys.exc_info()
-            raise exc_value
-
-        @staticmethod
-        def instance():
-            PollIOLoop.configure(DebugLoop)
-            return PollIOLoop.instance()
-
-        def start(self):
-            try:
-                super(DebugLoop, self).start()
-            except ZMQError as e:
-                if e.errno == ETERM:
-                    # quietly return on ETERM
-                    pass
-                else:
-                    raise e
-
     from tornado import ioloop
-    ioloop.IOLoop.configure(DebugLoop)
     return ioloop.IOLoop.instance()
 
 

--- a/circus/tests/test_stats_collector.py
+++ b/circus/tests/test_stats_collector.py
@@ -3,7 +3,7 @@ import time
 from collections import defaultdict
 from circus.fixed_threading import Thread
 
-from zmq.eventloop import ioloop
+from tornado import ioloop
 
 from circus.stats import collector as collector_module
 from circus.stats.collector import SocketStatsCollector, WatcherStatsCollector

--- a/circus/watcher.py
+++ b/circus/watcher.py
@@ -16,7 +16,7 @@ from tornado import gen
 
 from psutil import NoSuchProcess, TimeoutExpired
 import zmq.utils.jsonapi as json
-from zmq.eventloop import ioloop
+from tornado import ioloop
 
 from circus.process import Process, DEAD_OR_ZOMBIE, UNEXISTING
 from circus.papa_process_proxy import PapaProcessProxy

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ if not hasattr(sys, 'version_info') or sys.version_info < (2, 7, 0, 'final'):
     raise SystemExit("Circus requires Python 2.7 or higher.")
 
 
-install_requires = ['psutil', 'pyzmq>=13.1.0,<17.0', 'tornado>=3.0,<5.0', 'six']
+install_requires = ['psutil', 'pyzmq>=17.0', 'tornado>=3.0,<5.0', 'six']
 
 try:
     import argparse     # NOQA

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ deps =
     PyYAML
     six
     tornado>=3.0,<5.0
-    pyzmq>=13.1.0,<17.0
+    pyzmq>=17.0
 
 setenv =
     TESTING=1


### PR DESCRIPTION
Fixes #1099 

Update the dependency requirement `pyzmq>=17` and update the code
to adapt to corresponding API changes.

~~@k4nar This is blocked by PR #1110 that I opened that first fixes the CI on Travis.
I hope this PR will breath back some life into circus. I intend to look into porting the
code to `tornado>5` in the near future, but this is more complicated. Any help or
directions there would be very welcome.~~