### PR TITLE
graceful_timeout watcher config option should be float

### DIFF
--- a/circus/config.py
+++ b/circus/config.py
@@ -238,7 +238,7 @@ def get_config(config_file):
                     watcher['max_retry'] = dget(section, "max_retry", 5, int)
                 elif opt == 'graceful_timeout':
                     watcher['graceful_timeout'] = dget(
-                        section, "graceful_timeout", 30, int)
+                        section, "graceful_timeout", 30., float)
                 elif opt.startswith('stderr_stream') or \
                         opt.startswith('stdout_stream'):
                     stream_name, stream_opt = opt.split(".", 1)

--- a/circus/tests/config/issue1088.ini
+++ b/circus/tests/config/issue1088.ini
@@ -1,0 +1,6 @@
+[circus]
+check_delay = 5
+
+[watcher:my_app]
+cmd = boo
+graceful_timeout = 25.5

--- a/circus/tests/test_config.py
+++ b/circus/tests/test_config.py
@@ -46,6 +46,7 @@ _CONF = {
     'issue680': os.path.join(CONFIG_DIR, 'issue680.ini'),
     'virtualenv': os.path.join(CONFIG_DIR, 'virtualenv.ini'),
     'empty_section': os.path.join(CONFIG_DIR, 'empty_section.ini'),
+    'issue1088': os.path.join(CONFIG_DIR, 'issue1088.ini')
 }
 
 
@@ -386,6 +387,14 @@ class TestConfig(TestCase):
         conf = get_config(_CONF['empty_section'])
         self.assertEqual([], conf.get('sockets'))
         self.assertEqual([], conf.get('plugins'))
+
+    def test_issue1088(self):
+        # #1088 - graceful_timeout should be float
+        conf = get_config(_CONF['issue1088'])
+        watcher = conf['watchers'][0]
+        self.assertEqual(watcher['graceful_timeout'], 25.5)
+        watcher = Watcher.load_from_config(conf['watchers'][0])
+        watcher.stop()
 
 
 test_suite = EasyTestSuite(__name__)


### PR DESCRIPTION
Fixes #1088 

- change reading of graceful_timeout in config to float
- add separate test with graceful_timeout set as float