### PR TITLE
Add PyYAML version requirement to py34 tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,11 @@ deps =
 commands =
     nosetests -vs --with-coverage --cover-package=circus circus/tests
 
+[testenv:py34]
+deps =
+    {[testenv]deps}
+    PyYAML<5.3
+
 [testenv]
 passenv = PWD
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -14,17 +14,13 @@ deps =
 commands =
     nosetests -vs --with-coverage --cover-package=circus circus/tests
 
-[testenv:py34]
-deps =
-    {[testenv]deps}
-    PyYAML<5.3
-
 [testenv]
 passenv = PWD
 deps =
     nose
     mock
-    PyYAML
+    !py34: PyYAML
+    py34: PyYAML<5.3
     six
     tornado>=3.0,<5.0
     pyzmq>=17.0


### PR DESCRIPTION
PyYAML dropped support of python 3.4 in version 5.3 and tests started to fail. I added version requirement in tox config to fix this.