### PR TITLE
Speedup reload of configs with large number of sockets

### DIFF
--- a/circus/arbiter.py
+++ b/circus/arbiter.py
@@ -294,7 +294,9 @@ class Arbiter(object):
 
         # Gather socket names.
         current_sn = set([i.name for i in self.sockets.values()]) - ignore_sn
-        new_sockets = dict((i['name'], i.copy()) for i in new_cfg.get('sockets', []))
+        new_sockets = dict(
+            (i['name'], i.copy()) for i in new_cfg.get('sockets', [])
+        )
         new_sn = set(new_sockets.keys())
         added_sn = new_sn - current_sn
         deleted_sn = current_sn - new_sn

--- a/circus/arbiter.py
+++ b/circus/arbiter.py
@@ -250,12 +250,6 @@ class Arbiter(object):
     def get_socket(self, name):
         return self.sockets.get(name, None)
 
-    def get_socket_config(self, config, name):
-        for i in config.get('sockets', []):
-            if i['name'] == name:
-                return i.copy()
-        return None
-
     def get_watcher_config(self, config, name):
         for i in config.get('watchers', []):
             if i['name'] == name:
@@ -300,7 +294,8 @@ class Arbiter(object):
 
         # Gather socket names.
         current_sn = set([i.name for i in self.sockets.values()]) - ignore_sn
-        new_sn = set([i['name'] for i in new_cfg.get('sockets', [])])
+        new_sockets = dict((i['name'], i.copy()) for i in new_cfg.get('sockets', []))
+        new_sn = set(new_sockets.keys())
         added_sn = new_sn - current_sn
         deleted_sn = current_sn - new_sn
         maybechanged_sn = current_sn - deleted_sn
@@ -311,7 +306,7 @@ class Arbiter(object):
         # get changed sockets
         for n in maybechanged_sn:
             s = self.get_socket(n)
-            if self.get_socket_config(new_cfg, n) != s._cfg:
+            if new_sockets[n] != s._cfg:
                 changed_sn.add(n)
 
                 # just delete the socket and add it again
@@ -337,7 +332,7 @@ class Arbiter(object):
 
         # get added sockets
         for n in added_sn:
-            socket_config = self.get_socket_config(new_cfg, n)
+            socket_config = new_sockets[n]
             s = CircusSocket.load_from_config(socket_config)
             s.bind_and_listen()
             self.sockets[s.name] = s


### PR DESCRIPTION
This is just a touch up on #834 by @majek.

I removed all occurrences of `get_socket_config` and didn't change any other logic.

I have also tested the assumption that this change would speed up the reloading of the config. My method of test was the following:
- generate two fairly large configs (with at least 1000 sockets)
- make sure reloading happens more than once
- average out the time of execution using statistics module

All of the test files are [here](https://gist.github.com/biozz/7020a4d65f25245f45aab937f5482fb6).

On my machine the results were:
- with `get_socket_config`: ~0.23 sec
- without `get_socket_config`: ~0.18 sec

And on the other hand, the reloading of the smaller files (with 1-2 sockets) took almost the same time.

The change looks insignificant to me, but also "nice to have", because it doesn't impact existing configs.