### PR TITLE
Watcher include directive

### DIFF
--- a/circus/config.py
+++ b/circus/config.py
@@ -2,7 +2,7 @@ import glob
 import os
 import signal
 import warnings
-from configparser import RawConfigParser
+
 from fnmatch import fnmatch
 try:
     import resource
@@ -142,7 +142,7 @@ def read_config(config_path):
             # add section header for ConfigParser to understand it
             ini_str = '[tmp]\n' + open(include_path, 'r').read()
             ini_fp = StringIO(ini_str)
-            config = RawConfigParser()
+            config = StrictConfigParser()
             config.readfp(ini_fp)
             for name, value in config.items('tmp'):
                 cfg.set(section, name, value)

--- a/circus/config.py
+++ b/circus/config.py
@@ -138,13 +138,14 @@ def read_config(config_path):
         watcher_includes = []
         for include_file in cfg.dget(section, 'include', '').split():
             _scan(include_file, watcher_includes)
-        for p in watcher_includes:
-            ini_str = '[root]\n' + open(p, 'r').read()
+        for include_path in watcher_includes:
+            # add section header for ConfigParser to understand it
+            ini_str = '[tmp]\n' + open(include_path, 'r').read()
             ini_fp = StringIO(ini_str)
             config = RawConfigParser()
             config.readfp(ini_fp)
-            # replace watcher config option
-            # with ones from config
+            for name, value in config.items('tmp'):
+                cfg.set(section, name, value)
 
     return cfg
 

--- a/circus/tests/config/issue1119.ini
+++ b/circus/tests/config/issue1119.ini
@@ -1,0 +1,6 @@
+[circus]
+pidfile = pidfile
+
+[watcher:server]
+cmd = echo
+include = issue1119_include.ini

--- a/circus/tests/config/issue1119_include.ini
+++ b/circus/tests/config/issue1119_include.ini
@@ -1,0 +1,1 @@
+numprocesses = 5

--- a/circus/tests/test_config.py
+++ b/circus/tests/test_config.py
@@ -46,7 +46,8 @@ _CONF = {
     'issue680': os.path.join(CONFIG_DIR, 'issue680.ini'),
     'virtualenv': os.path.join(CONFIG_DIR, 'virtualenv.ini'),
     'empty_section': os.path.join(CONFIG_DIR, 'empty_section.ini'),
-    'issue1088': os.path.join(CONFIG_DIR, 'issue1088.ini')
+    'issue1088': os.path.join(CONFIG_DIR, 'issue1088.ini'),
+    'watcher_include': os.path.join(CONFIG_DIR, 'issue1119.ini')
 }
 
 
@@ -196,6 +197,11 @@ class TestConfig(TestCase):
         except:  # noqa: E722
             self.fail('Non-existent includes should not raise')
         self.assertTrue(mock_logger_warn.called)
+
+    def test_watcher_include(self):
+        conf = get_config(_CONF['watcher_include'])
+        watchers = conf['watchers']
+        self.assertEqual(watchers[0]['numprocesses'], 5)
 
     def test_watcher_graceful_timeout(self):
         conf = get_config(_CONF['issue210'])

--- a/circus/tests/test_config.py
+++ b/circus/tests/test_config.py
@@ -47,7 +47,7 @@ _CONF = {
     'virtualenv': os.path.join(CONFIG_DIR, 'virtualenv.ini'),
     'empty_section': os.path.join(CONFIG_DIR, 'empty_section.ini'),
     'issue1088': os.path.join(CONFIG_DIR, 'issue1088.ini'),
-    'watcher_include': os.path.join(CONFIG_DIR, 'issue1119.ini')
+    'issue1119': os.path.join(CONFIG_DIR, 'issue1119.ini')
 }
 
 
@@ -197,11 +197,6 @@ class TestConfig(TestCase):
         except:  # noqa: E722
             self.fail('Non-existent includes should not raise')
         self.assertTrue(mock_logger_warn.called)
-
-    def test_watcher_include(self):
-        conf = get_config(_CONF['watcher_include'])
-        watchers = conf['watchers']
-        self.assertEqual(watchers[0]['numprocesses'], 5)
 
     def test_watcher_graceful_timeout(self):
         conf = get_config(_CONF['issue210'])
@@ -401,6 +396,12 @@ class TestConfig(TestCase):
         self.assertEqual(watcher['graceful_timeout'], 25.5)
         watcher = Watcher.load_from_config(conf['watchers'][0])
         watcher.stop()
+
+    def test_watcher_issue_1119(self):
+        # #1119 - add support for include directive in watcher section
+        conf = get_config(_CONF['issue1119'])
+        watchers = conf['watchers']
+        self.assertEqual(watchers[0]['numprocesses'], 5)
 
 
 test_suite = EasyTestSuite(__name__)


### PR DESCRIPTION
This can be considered as proof of concept for #1119 and it is still "work in progress".

I added support for include directive in watcher section, which is compatible across currently supported versions.

These are the things that I want to improve:

- [ ] reduce amount of loops
- [ ] add support for include_dir (questionable)
- [ ] avoid use of magic section header
- [ ] add custom parser for better error handling
- [ ] add more tests