### PR TITLE
Keep a changelog

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -4,7 +4,7 @@ Changelog history
 unreleased
 ----------
 
-- Fix mem_info readings to be more reliable - #1127
+- Fix mem_info readings to be more reliable - #1128
 - Drop support for Python 2.7 & 3.4 - #1126
 - Speedup reloadconfig for large number of sockets - #1121
 - Do not allow adding watchers with the same lowercase names - #1117

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -4,10 +4,12 @@ Changelog history
 unreleased
 ----------
 
-- Speedup reloadconfig for large number of sockets - #834
-- Do not allow adding watchers with the same lowercase names - #936
-- Do not delete pid file during restart - #1080
-- Fix graceful_timeout watcher config option type - #1088
+- Fix mem_info readings to be more reliable - #1127
+- Drop support for Python 2.7 & 3.4 - #1126
+- Speedup reloadconfig for large number of sockets - #1121
+- Do not allow adding watchers with the same lowercase names - #1117
+- Do not delete pid file during restart - #1116
+- Fix graceful_timeout watcher config option type - #1115
 
 0.16.1 2019-12-27
 -----------------

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,14 @@
 Changelog history
 =================
 
+unreleased
+----------
+
+- Speedup reloadconfig for large number of sockets - #834
+- Do not allow adding watchers with the same lowercase names - #936
+- Do not delete pid file during restart - #1080
+- Fix graceful_timeout watcher config option type - #1088
+
 0.16.1 2019-12-27
 -----------------
 Fix packaging issue.

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -53,6 +53,9 @@ testsuite under the different supported python versions.
 Please use : http://issue2pr.herokuapp.com/ to reference a commit to an
 existing circus issue, if any.
 
+Please also add a changelog entry in the 'unreleased' section with a short
+description of the change and a reference to the issue (if any).
+
 Avoiding merge commits
 ======================
 


### PR DESCRIPTION
I added unreleased section to changelog after being inspired by [keepachangelog](https://keepachangelog.com/) project.

I have also added a small note to contributing guide with a reminder to add such entries.