### PR TITLE
Fix mem_info readings to be more reliable

### DIFF
--- a/circus/tests/test_util.py
+++ b/circus/tests/test_util.py
@@ -92,8 +92,11 @@ class TestUtil(TestCase):
         self.assertEqual(util.convert_opt('test', 1), '1')
 
     def test_bytes2human(self):
-        self.assertEqual(bytes2human(10000), '9K')
-        self.assertEqual(bytes2human(100001221), '95M')
+        self.assertEqual(bytes2human(100), '100B')
+        self.assertEqual(bytes2human(10000), '9.76K')
+        self.assertEqual(bytes2human(100001221), '95.36M')
+        self.assertEqual(bytes2human(1024 * 1024 * 2047), '1.99G')
+        self.assertEqual(bytes2human(1024 * 1024 * 2048), '2.00G')
         self.assertRaises(TypeError, bytes2human, '1')
 
     def test_human2bytes(self):
@@ -102,6 +105,8 @@ class TestUtil(TestCase):
         self.assertEqual(human2bytes('1129M'), 1183842304)
         self.assertEqual(human2bytes('67T'), 73667279060992)
         self.assertEqual(human2bytes('13P'), 14636698788954112)
+        self.assertEqual(human2bytes('1.99G'), 2136746229)
+        self.assertEqual(human2bytes('2.00G'), 2147483648)
         self.assertRaises(ValueError, human2bytes, '')
         self.assertRaises(ValueError, human2bytes, 'faoej')
         self.assertRaises(ValueError, human2bytes, '123KB')

--- a/circus/tests/test_util.py
+++ b/circus/tests/test_util.py
@@ -93,10 +93,9 @@ class TestUtil(TestCase):
 
     def test_bytes2human(self):
         self.assertEqual(bytes2human(100), '100B')
-        self.assertEqual(bytes2human(10000), '9.76K')
-        self.assertEqual(bytes2human(100001221), '95.36M')
-        self.assertEqual(bytes2human(1024 * 1024 * 2047), '1.99G')
-        self.assertEqual(bytes2human(1024 * 1024 * 2048), '2.00G')
+        self.assertEqual(bytes2human(10000), '9.77K')
+        self.assertEqual(bytes2human(100001221), '95.37M')
+        self.assertEqual(bytes2human(1024 * 1024 * 2047), '2.00G')
         self.assertRaises(TypeError, bytes2human, '1')
 
     def test_human2bytes(self):

--- a/circus/util.py
+++ b/circus/util.py
@@ -144,13 +144,8 @@ def bytes2human(n):
 
     for s in reversed(_SYMBOLS):
         if n >= prefix[s]:
-            # truncate to 2 decimal places without rounding
-            # https://stackoverflow.com/questions/783897/truncating-floats-in-python
-            value = '{}'.format(float(n) / prefix[s])
-            i, p, d = value.partition('.')
-            decimal_places = 2
-            value = '.'.join([i, (d+'0'*decimal_places)[:decimal_places]])
-            return '%s%s' % (value, s)
+            value = round(float(n) / prefix[s], 2)
+            return '{:.2f}{}'.format(value, s)
     return "%sB" % n
 
 

--- a/circus/util.py
+++ b/circus/util.py
@@ -144,7 +144,12 @@ def bytes2human(n):
 
     for s in reversed(_SYMBOLS):
         if n >= prefix[s]:
-            value = int(float(n) / prefix[s])
+            # truncate to 2 decimal places without rounding
+            # https://stackoverflow.com/questions/783897/truncating-floats-in-python
+            value = '{}'.format(float(n) / prefix[s])
+            i, p, d = value.partition('.')
+            decimal_places = 2
+            value = '.'.join([i, (d+'0'*decimal_places)[:decimal_places]])
             return '%s%s' % (value, s)
     return "%sB" % n
 


### PR DESCRIPTION
This fixes #1127.

- add conversion to string and cutting to 2 decimal places
- add tests for edge cases with 1.99G and 2.00G