### PR TITLE
circus with new tornado>5.0.2

### DIFF
--- a/circus/arbiter.py
+++ b/circus/arbiter.py
@@ -242,7 +242,7 @@ class Arbiter(object):
     def _init_context(self, context):
         self.context = context or zmq.Context.instance()
         if self.loop is None:
-            self.loop = ioloop.IOLoop.instance()
+            self.loop = ioloop.IOLoop.current()
         self.ctrl = Controller(self.endpoint, self.multicast_endpoint,
                                self.context, self.loop, self, self.check_delay,
                                self.endpoint_owner)

--- a/circus/client.py
+++ b/circus/client.py
@@ -67,6 +67,7 @@ class AsyncCircusClient(object):
 
         try:
             future = concurrent.Future()
+
             def cb(msg, status):
                 future.set_result(msg)
             self.stream.send(cmd, callback=cb)

--- a/circus/client.py
+++ b/circus/client.py
@@ -5,6 +5,7 @@ import zmq
 import zmq.utils.jsonapi as json
 from zmq.eventloop.zmqstream import ZMQStream
 import tornado
+from tornado import concurrent
 
 from circus.exc import CallError
 from circus.util import DEFAULT_ENDPOINT_DEALER, get_connection, to_bytes
@@ -65,12 +66,19 @@ class AsyncCircusClient(object):
             raise CallError(str(e))
 
         try:
-            yield tornado.gen.Task(self.stream.send, cmd)
+            future = concurrent.Future()
+            def cb(msg, status):
+                future.set_result(msg)
+            self.stream.send(cmd, callback=cb)
+            yield future
         except zmq.ZMQError as e:
             raise CallError(str(e))
 
         while True:
-            messages = yield tornado.gen.Task(self.stream.on_recv)
+            future = concurrent.Future()
+            self.stream.on_recv(future.set_result)
+            messages = yield future
+
             for message in messages:
                 try:
                     res = json.loads(message)

--- a/circus/client.py
+++ b/circus/client.py
@@ -36,7 +36,7 @@ class AsyncCircusClient(object):
         get_connection(self.socket, endpoint, ssh_server, ssh_keyfile)
         self._timeout = timeout
         self.timeout = timeout * 1000
-        self.stream = ZMQStream(self.socket, tornado.ioloop.IOLoop.instance())
+        self.stream = ZMQStream(self.socket, tornado.ioloop.IOLoop.current())
 
     def _init_context(self, context):
         self.context = context or zmq.Context.instance()

--- a/circus/controller.py
+++ b/circus/controller.py
@@ -109,7 +109,7 @@ class Controller(object):
             # so with no period callback to manage_watchers
             # is probably "unit tests only"
             self.caller = ioloop.PeriodicCallback(self.manage_watchers,
-                                                  self.check_delay, self.loop)
+                                                  self.check_delay)
             self.caller.start()
         self.started = True
 

--- a/circus/green/arbiter.py
+++ b/circus/green/arbiter.py
@@ -8,6 +8,6 @@ from zmq.green import Context
 class Arbiter(_Arbiter):
     def _init_context(self, context):
         self.context = context or Context.instance()
-        self.loop = ioloop.IOLoop.instance()
+        self.loop = ioloop.IOLoop.current()
         self.ctrl = Controller(self.endpoint, self.multicast_endpoint,
                                self.context, self.loop, self, self.check_delay)

--- a/circus/green/controller.py
+++ b/circus/green/controller.py
@@ -14,7 +14,8 @@ class Controller(_Controller):
         self.stream.on_recv(self.handle_message)
 
     def start(self):
+        self.loop.make_current()
         self.initialize()
         self.caller = ioloop.PeriodicCallback(self.arbiter.manage_watchers,
-                                              self.check_delay, self.loop)
+                                              self.check_delay)
         self.caller.start()

--- a/circus/plugins/__init__.py
+++ b/circus/plugins/__init__.py
@@ -58,6 +58,7 @@ class CircusPlugin(object):
 
     @debuglog
     def start(self):
+        self.loop.make_current()
         if not self.active:
             raise ValueError('Will not start an inactive plugin')
         self.handle_init()

--- a/circus/plugins/command_reloader.py
+++ b/circus/plugins/command_reloader.py
@@ -48,8 +48,7 @@ class CommandReloader(CircusPlugin):
 
     def handle_init(self):
         self.period = ioloop.PeriodicCallback(self.look_after,
-                                              self.loop_rate * 1000,
-                                              self.loop)
+                                              self.loop_rate * 1000)
         self.period.start()
 
     def handle_stop(self):

--- a/circus/plugins/statsd.py
+++ b/circus/plugins/statsd.py
@@ -81,7 +81,7 @@ class BaseObserver(StatsdEmitter):
 
     def handle_init(self):
         self.period = ioloop.PeriodicCallback(self.look_after,
-                                              self.loop_rate * 1000, self.loop)
+                                              self.loop_rate * 1000)
         self.period.start()
 
     def handle_stop(self):

--- a/circus/plugins/watchdog.py
+++ b/circus/plugins/watchdog.py
@@ -79,8 +79,7 @@ class WatchDog(CircusPlugin):
         - create the listening UDP socket
         """
         self.period = ioloop.PeriodicCallback(self.look_after,
-                                              self.loop_rate * 1000,
-                                              self.loop)
+                                              self.loop_rate * 1000)
         self.period.start()
         self._bind_socket()
 

--- a/circus/stats/collector.py
+++ b/circus/stats/collector.py
@@ -12,7 +12,7 @@ class BaseStatsCollector(ioloop.PeriodicCallback):
 
     def __init__(self, streamer, name, callback_time=1., io_loop=None):
         ioloop.PeriodicCallback.__init__(self, self._callback,
-                                         callback_time * 1000, io_loop)
+                                         callback_time * 1000)
         self.streamer = streamer
         self.name = name
 
@@ -110,8 +110,7 @@ class SocketStatsCollector(BaseStatsCollector):
                                                    callback_time, io_loop)
         self._rstats = defaultdict(int)
         self.sockets = [sock for sock, address, fd in self.streamer.sockets]
-        self._p = ioloop.PeriodicCallback(self._select, _LOOP_RES,
-                                          io_loop=io_loop)
+        self._p = ioloop.PeriodicCallback(self._select, _LOOP_RES)
 
     def start(self):
         self._p.start()

--- a/circus/stats/streamer.py
+++ b/circus/stats/streamer.py
@@ -27,7 +27,7 @@ class StatsStreamer(object):
         self.sub_socket = self.ctx.socket(zmq.SUB)
         self.sub_socket.setsockopt(zmq.SUBSCRIBE, self.topic)
         self.sub_socket.connect(self.pubsub_endpoint)
-        self.loop = loop or ioloop.IOLoop.instance()
+        self.loop = loop or ioloop.IOLoop.current()
         self.substream = zmqstream.ZMQStream(self.sub_socket, self.loop)
         self.substream.on_recv(self.handle_recv)
         self.client = CircusClient(context=self.ctx, endpoint=endpoint,

--- a/circus/stream/redirector.py
+++ b/circus/stream/redirector.py
@@ -42,7 +42,7 @@ class Redirector(object):
         self._active = {}
         self.redirect = {'stdout': stdout_redirect, 'stderr': stderr_redirect}
         self.buffer = buffer
-        self.loop = loop or ioloop.IOLoop.instance()
+        self.loop = loop or ioloop.IOLoop.current()
 
     def _start_one(self, fd, stream_name, process, pipe):
         if fd not in self._active:

--- a/circus/tests/support.py
+++ b/circus/tests/support.py
@@ -51,7 +51,7 @@ SLEEP = PYTHON + " -c 'import time;time.sleep(%d)'"
 
 def get_ioloop():
     from tornado import ioloop
-    return ioloop.IOLoop.instance()
+    return ioloop.IOLoop.current()
 
 
 def get_available_port():

--- a/circus/tests/support.py
+++ b/circus/tests/support.py
@@ -11,6 +11,7 @@ import functools
 import multiprocessing
 import socket
 import sysconfig
+import concurrent
 
 from unittest import skip, skipIf, TestCase, TestSuite, findTestCases  # noqa: F401
 
@@ -472,8 +473,7 @@ class FakeProcess(object):
     def stop(self):
         pass
 
-
-class MagicMockFuture(mock.MagicMock, tornado.concurrent.Future):
+class MagicMockFuture(mock.MagicMock, concurrent.futures.Future):
 
     def cancel(self):
         return False

--- a/circus/tests/support.py
+++ b/circus/tests/support.py
@@ -473,6 +473,7 @@ class FakeProcess(object):
     def stop(self):
         pass
 
+
 class MagicMockFuture(mock.MagicMock, concurrent.futures.Future):
 
     def cancel(self):

--- a/circus/tests/support.py
+++ b/circus/tests/support.py
@@ -15,7 +15,7 @@ import sysconfig
 from unittest import skip, skipIf, TestCase, TestSuite, findTestCases  # noqa: F401
 
 from tornado.testing import AsyncTestCase
-import mock
+from unittest import mock
 import tornado
 
 from circus import get_arbiter

--- a/circus/tests/test_arbiter.py
+++ b/circus/tests/test_arbiter.py
@@ -500,6 +500,7 @@ class TestTrainer(TestCircus):
                                  loop=get_ioloop())
 
         def incr_processes(cli):
+            # return a coroutine if cli is Async
             return cli.send_message('incr', name='test')
 
         # wait for the plugin to be started
@@ -511,7 +512,6 @@ class TestTrainer(TestCircus):
         res = yield cli.send_message('list', name='test')
         self.assertEqual(len(res.get('pids')), 1)
 
-        # XXX: NOT SURE, yield make procedure sync
         yield incr_processes(cli)
         res = yield cli.send_message('list', name='test')
         self.assertEqual(len(res.get('pids')), 2)

--- a/circus/tests/test_arbiter.py
+++ b/circus/tests/test_arbiter.py
@@ -633,6 +633,21 @@ class TestArbiter(TestCircus):
 
         self.assertEqual(callee.call_count, 1)
 
+    def test_start_with_callback_delay(self):
+        controller = "tcp://127.0.0.1:%d" % get_available_port()
+        sub = "tcp://127.0.0.1:%d" % get_available_port()
+        arbiter = Arbiter([], controller, sub, check_delay=1)
+
+        callee = mock.MagicMock()
+
+        def callback(*args):
+            callee()
+            arbiter.stop()
+
+        arbiter.start(cb=callback)
+
+        self.assertEqual(callee.call_count, 1)
+
     @tornado.testing.gen_test
     def test_start_with_callback_and_given_loop(self):
         controller = "tcp://127.0.0.1:%d" % get_available_port()

--- a/circus/tests/test_arbiter.py
+++ b/circus/tests/test_arbiter.py
@@ -511,7 +511,8 @@ class TestTrainer(TestCircus):
         res = yield cli.send_message('list', name='test')
         self.assertEqual(len(res.get('pids')), 1)
 
-        incr_processes(cli)
+        # XXX: NOT SURE, yield make procedure sync
+        yield incr_processes(cli)
         res = yield cli.send_message('list', name='test')
         self.assertEqual(len(res.get('pids')), 2)
         # wait for the plugin to receive the signal
@@ -519,7 +520,7 @@ class TestTrainer(TestCircus):
         self.assertTrue(res)
         truncate_file(datafile)
 
-        incr_processes(cli)
+        yield incr_processes(cli)
         res = yield cli.send_message('list', name='test')
         self.assertEqual(len(res.get('pids')), 3)
 
@@ -595,8 +596,7 @@ class TestTrainer(TestCircus):
         @tornado.gen.coroutine
         def _sleep(duration):
             called.append(duration)
-            loop = get_ioloop()
-            yield tornado.gen.Task(loop.add_timeout, time() + duration)
+            yield tornado.gen.sleep(duration)
 
         watcher_mod.tornado_sleep = _sleep
 

--- a/circus/tests/test_arbiter.py
+++ b/circus/tests/test_arbiter.py
@@ -5,7 +5,7 @@ import tornado
 from tempfile import mkstemp
 from time import time
 import zmq.utils.jsonapi as json
-import mock
+from unittest import mock
 from urllib.parse import urlparse
 
 from circus.arbiter import Arbiter

--- a/circus/tests/test_circusctl.py
+++ b/circus/tests/test_circusctl.py
@@ -1,6 +1,6 @@
 import subprocess
 import shlex
-from mock import patch
+from unittest.mock import patch
 from multiprocessing import Process, Queue
 
 from tornado.testing import gen_test

--- a/circus/tests/test_config.py
+++ b/circus/tests/test_config.py
@@ -1,6 +1,6 @@
 import os
 import signal
-from mock import patch
+from unittest.mock import patch
 
 from circus import logger
 from circus.arbiter import Arbiter

--- a/circus/tests/test_controller.py
+++ b/circus/tests/test_controller.py
@@ -4,7 +4,7 @@ from circus.util import DEFAULT_ENDPOINT_MULTICAST
 from circus import logger
 import circus.controller
 
-import mock
+from unittest import mock
 
 
 class TestController(TestCase):

--- a/circus/tests/test_plugin_command_reloader.py
+++ b/circus/tests/test_plugin_command_reloader.py
@@ -1,4 +1,4 @@
-from mock import patch
+from unittest.mock import patch
 
 from circus.plugins.command_reloader import CommandReloader
 from circus.tests.support import TestCircus, EasyTestSuite

--- a/circus/tests/test_plugin_flapping.py
+++ b/circus/tests/test_plugin_flapping.py
@@ -1,4 +1,4 @@
-from mock import patch
+from unittest.mock import patch
 
 from circus.tests.support import TestCircus, EasyTestSuite
 from circus.plugins.flapping import Flapping

--- a/circus/tests/test_reloadconfig.py
+++ b/circus/tests/test_reloadconfig.py
@@ -55,10 +55,10 @@ class TestConfig(tornado.testing.AsyncTestCase):
         a.sockets.close_all()
 
     def get_new_ioloop(self):
-        return tornado.ioloop.IOLoop.instance()
+        return tornado.ioloop.IOLoop.current()
 
     def _load_base_arbiter(self, name='reload_base'):
-        loop = tornado.ioloop.IOLoop.instance()
+        loop = tornado.ioloop.IOLoop.current()
         a = Arbiter.load_from_config(_CONF[name], loop=loop)
         a.evpub_socket = FakeSocket()
         # initialize watchers

--- a/circus/tests/test_sockets.py
+++ b/circus/tests/test_sockets.py
@@ -5,7 +5,7 @@ try:
     import IN
 except ImportError:
     pass
-import mock
+from unittest import mock
 import fcntl
 
 from circus.tests.support import TestCase, skipIf, EasyTestSuite, IS_WINDOWS

--- a/circus/tests/test_stats_collector.py
+++ b/circus/tests/test_stats_collector.py
@@ -72,6 +72,7 @@ class TestCollector(TestCase):
                 this.daemon = True
 
             def run(self):
+                self.loop.make_current()
                 collector = collector_class(
                     self.streamer, 'sockets', callback_time=0.1,
                     io_loop=self.loop)

--- a/circus/tests/test_stats_publisher.py
+++ b/circus/tests/test_stats_publisher.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 
 import zmq
 import zmq.utils.jsonapi as json

--- a/circus/tests/test_stats_streamer.py
+++ b/circus/tests/test_stats_streamer.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 
-import mock
+from unittest import mock
 
 from circus.tests.support import TestCircus, EasyTestSuite
 from circus.stats.streamer import StatsStreamer

--- a/circus/tests/test_util.py
+++ b/circus/tests/test_util.py
@@ -13,7 +13,7 @@ except ImportError:
 
 import psutil
 from psutil import Popen
-import mock
+from unittest import mock
 
 from circus.tests.support import (TestCase, EasyTestSuite, skipIf,
                                   IS_WINDOWS, SLEEP)

--- a/circus/tests/test_validate_option.py
+++ b/circus/tests/test_validate_option.py
@@ -1,5 +1,5 @@
 from circus.tests.support import TestCase, EasyTestSuite, IS_WINDOWS
-from mock import patch
+from unittest.mock import patch
 
 from circus.commands.util import validate_option
 from circus.exc import MessageError

--- a/circus/tests/test_watcher.py
+++ b/circus/tests/test_watcher.py
@@ -16,7 +16,7 @@ except ImportError:
         captured_output = None  # NOQA
 
 import tornado
-import mock
+from unittest import mock
 
 from circus import logger
 from circus.process import RUNNING, UNEXISTING

--- a/circus/tests/test_watcher.py
+++ b/circus/tests/test_watcher.py
@@ -317,7 +317,7 @@ class SomeWatcher(object):
         self.watcher = None
         self.kw = kw
         if loop is None:
-            self.loop = tornado.ioloop.IOLoop.instance()
+            self.loop = tornado.ioloop.IOLoop.current()
         else:
             self.loop = loop
 

--- a/circus/util.py
+++ b/circus/util.py
@@ -26,7 +26,6 @@ except ImportError:
     fcntl = None
     grp = None
     pwd = None
-from tornado.ioloop import IOLoop
 from tornado import gen
 from tornado import concurrent
 
@@ -1048,7 +1047,7 @@ def tornado_sleep(duration):
     To use with a gen.coroutines decorated function
     Thanks to http://stackoverflow.com/a/11135204/433050
     """
-    return gen.Task(IOLoop.instance().add_timeout, time.time() + duration)
+    return gen.sleep(duration)
 
 
 class TransformableFuture(concurrent.Future):

--- a/circus/util.py
+++ b/circus/util.py
@@ -1032,7 +1032,7 @@ def synchronized(name):
             finally:
                 if isinstance(resp, concurrent.Future):
                     cb = functools.partial(_synchronized_cb, arbiter)
-                    resp.add_done_callback(cb)
+                    concurrent.future_add_done_callback(resp, cb)
                 else:
                     if arbiter is not None:
                         arbiter._exclusive_running_command = None

--- a/circus/watcher.py
+++ b/circus/watcher.py
@@ -242,7 +242,7 @@ class Watcher(object):
         self.close_child_stdout = close_child_stdout
         self.close_child_stderr = close_child_stderr
         self.use_papa = use_papa and papa is not None
-        self.loop = loop or ioloop.IOLoop.instance()
+        self.loop = loop or ioloop.IOLoop.current()
 
         if singleton and self.numprocesses not in (0, 1):
             raise ValueError("Cannot have %d processes with a singleton "

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -4,6 +4,7 @@ Changelog history
 unreleased
 ----------
 
+- Drop support for tornado<5 and start using asyncio eventl loop - #1129
 - Fix mem_info readings to be more reliable - #1128
 - Drop support for Python 2.7 & 3.4 - #1126
 - Speedup reloadconfig for large number of sockets - #1121

--- a/examples/test.sh
+++ b/examples/test.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
-;sleep 1
+sleep 1
+echo "@@@"

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,21 @@ setup(name='circus',
           "License :: OSI Approved :: Apache Software License"
       ],
       install_requires=install_requires,
+      extras_require={
+        'test': [
+            'nose',
+            'nose-cov',
+            'coverage',
+            'mock',
+            'circus-web',
+            'gevent',
+            'papa',
+            'PyYAML',
+            'tornado>=3.0,<5.0',
+            'pyzmq>=17.0',
+            'flake8==2.1.0',
+        ],
+      },
       test_suite='circus.tests',
       entry_points="""
       [console_scripts]

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ if not hasattr(sys, 'version_info') or sys.version_info < (3, 5, 0, 'final'):
     raise SystemExit("Circus requires Python 3.5 or higher.")
 
 
-install_requires = ['psutil', 'pyzmq>=17.0', 'tornado>=3.0,<5.0']
+install_requires = ['psutil', 'pyzmq>=17.0', 'tornado>=5.0.2']
 
 try:
     import argparse     # NOQA
@@ -46,7 +46,6 @@ setup(name='circus',
             'gevent',
             'papa',
             'PyYAML',
-            'tornado>=3.0,<5.0',
             'pyzmq>=17.0',
             'flake8==2.1.0',
         ],

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
     gevent
     papa
     PyYAML
-    tornado>=3.0,<5.0
+    tornado>=5.0.2
     pyzmq>=17.0
 
 setenv =


### PR DESCRIPTION
The minimal changes to make circus running with asyncio event loop (tornado>5.0.2). 

As mentioned in https://github.com/circus-tent/circus/issues/1124 , but instead of directly upgrade the package to compatible with `asyncio` I start here try to replace old tornado with `tornado>5.0.2` which uses the asyncio event loop. If there is a need to move forward, this is also a good archiving point. The following changes are included:

- replace third party `mock` package to `unittest.mock` since the `py<3` support is deprecated.
- add extra [test] packages in `setup.py` to let running test easier locally
- `gen.Task` is deprecated in new tornado replace it with setting future result in callback
- `_asyncio.Future` can not be inherited and then initialized so `MagicMockFuture` inherit from `concurrent.futures.Future` instead.
- `PeriodicCallback` no longer receive loop, have to set event loop to the correct one before running the callback.

In this PR, I only change the code which make all unit tests passed. As addition, also running examples as some sort of blackbox testing. Not sure about are there more code involved with asynchronous programming? 

Pinning @biozz @k4nar to have a look at this PR take a moment to review. And tagging @sphuber @ltalirz for suggestions.

`tornado>5; <5.0.2` is not supported since there is a bug which prevent event loop from successfully closing fixed in `5.0.2` [1] .

[1] https://www.tornadoweb.org/en/stable/releases/v5.0.2.html