### PR TITLE
Fix #1131(workaround): explicitly code `__stop` in `stop` and `restart` methods of `Arbiter` class

### DIFF
--- a/circus/watcher.py
+++ b/circus/watcher.py
@@ -782,10 +782,11 @@ class Watcher(object):
         """
         active_processes = self.get_active_processes()
         try:
-            yield [self.kill_process(process,
-                                     stop_signal=stop_signal,
-                                     graceful_timeout=graceful_timeout)
-                   for process in active_processes]
+            futures = [self.kill_process(process,
+                       stop_signal=stop_signal,
+                       graceful_timeout=graceful_timeout)
+                       for process in active_processes]
+            yield gen.multi(futures)
         except OSError as e:
             if e.errno != errno.ESRCH:
                 raise


### PR DESCRIPTION
Issue #1131  when `quit` or `restart` is called with
`waiting` option, `arbiter.stop` is running to stop all the watchers,
processes, however, somehow `arbiter.stop()` is a coroutine which return
the Future is never get finished. Therefore, callback
`_dispatch_callback_future` of `controller` never get run.

After lots of debug attempts I find two workarounds.

1. When stop watchers and calling `Watcher().kill_process` do not wait
   `tornado_sleep(0.1)` if process is still alive. This may cause some
   unexpected side effects.
2. Just explicitly implement `__stop()` method of `Arbiter` class in
   `stop()` and `restart()`. vvvery strange!!! Anyway, this doesn't
   affect the code logic but get issue solved, so adapt to
   workaround.

pinging @biozz @k4nar for inputs.