### PR TITLE
Change ConfigParser to RawConfig parser to avoid interpolation errors

### DIFF
--- a/circus/util.py
+++ b/circus/util.py
@@ -30,7 +30,7 @@ from tornado import gen
 from tornado import concurrent
 
 from configparser import (
-    ConfigParser, MissingSectionHeaderError, ParsingError, DEFAULTSECT
+    RawConfigParser, MissingSectionHeaderError, ParsingError, DEFAULTSECT
 )
 
 from urllib.parse import urlparse
@@ -752,7 +752,7 @@ def configure_logger(logger, level='INFO', output="-", loggerconfig=None,
                             % (shell_escape_arg(loggerconfig),))
 
 
-class StrictConfigParser(ConfigParser):
+class StrictConfigParser(RawConfigParser):
 
     def _read(self, fp, fpname):
         cursect = None                        # None, or a dictionary

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -4,6 +4,7 @@ Changelog history
 unreleased
 ----------
 
+- Change ConfigParser to RawConfigParser to avoid interpolation errors - #1133
 - Drop support for tornado<5 and start using asyncio eventl loop - #1129
 - Fix mem_info readings to be more reliable - #1128
 - Drop support for Python 2.7 & 3.4 - #1126

--- a/examples/example2.ini
+++ b/examples/example2.ini
@@ -15,6 +15,7 @@ numprocesses = 10
 stdout_stream.class = FileStream
 stdout_stream.filename = test.log
 stdout_stream.refresh_time = 0.3
+stdout_stream.time_format = '%Y/%m/%d | %H:%M:%S'
 
 [watcher:verbose2]
 cmd = python


### PR DESCRIPTION
Closes #1097.

The first implementation of time_format feature was done in #493, there was also a test, which checked that the feature works as expected.

But the test was designed in such a way that it used `FileStream` class and not the configuration file (like some other tests). Therefore the error described in #1097 wouldn't appear.

I changed `ConfigParser` to `RawConfigParser`, because it seems that interpolation feature, which is specific to `ConfigParser`, is not widely used and is not described in the documentation. So there is no reason to use `ConfigParser`.

I added `time_format` to `example2.ini` and did not add more tests, because if it not breaks and all of the other tests are working, then it should be OK.