### PR TITLE
Add windows-curses dependency for Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,12 @@ if not hasattr(sys, 'version_info') or sys.version_info < (3, 5, 0, 'final'):
     raise SystemExit("Circus requires Python 3.5 or higher.")
 
 
-install_requires = ['psutil', 'pyzmq>=17.0', 'tornado>=5.0.2']
+install_requires = [
+    'psutil',
+    'pyzmq>=17.0',
+    'tornado>=5.0.2',
+    'windows-curses>=2.10;platform_system=="Windows"',
+]
 
 try:
     import argparse     # NOQA


### PR DESCRIPTION
Closes #1100.

Disclaimer: I am using macOS and have difficulties setting up Windows environment to test this feature, so I would like to have some feedback from Windows users out there, pinging @ltalirz.