### PR TITLE
Add decoding of data when receiving watchdog message

### DIFF
--- a/circus/plugins/watchdog.py
+++ b/circus/plugins/watchdog.py
@@ -181,7 +181,7 @@ class WatchDog(CircusPlugin):
         :return: decoded message
         :rtype: dict or None
         """
-        result = re.match(self.msg_regex, data)
+        result = re.match(self.msg_regex, data.decode())
         if result is not None:
             return result.groupdict()
 
@@ -200,7 +200,7 @@ class WatchDog(CircusPlugin):
                 self.pid_status[heartbeat["pid"]][
                     'last_activity'] = time.time()
             else:
-                logger.warning("received watchdog for a"
+                logger.warning("received watchdog for a "
                                "non monitored process:%s",
                                heartbeat)
         logger.debug("watchdog message: %s", heartbeat)


### PR DESCRIPTION
Closes #1105.

The main change is adding `decode`, because it is sent over socket as bytes. I also fixed small typing error in the warning.

Unfortunately I couldn't figure out how to reproduce this bug in a test case. It would be great if I could get some help with that. On the other hand I can see that there is no exception (`TypeError`) when executing tests, so `decode` does not make it worse.