### PR TITLE
Fix failing resource watcher tests related to max_mem

### DIFF
--- a/circus/tests/test_plugin_resource_watcher.py
+++ b/circus/tests/test_plugin_resource_watcher.py
@@ -6,9 +6,9 @@ from circus.tests.support import TestCircus, async_poll_for, Process
 from circus.tests.support import async_run_plugin, EasyTestSuite
 from circus.plugins.resource_watcher import ResourceWatcher
 
-# Make sure we don't allow more than 300MB in case things go wrong
+# Make sure we don't allow more than 600MB in case things go wrong
 MAX_CHUNKS = 1000000
-CHUNK_SIZE = 300
+CHUNK_SIZE = 600
 
 
 class Leaky(Process):


### PR DESCRIPTION
Closes #1140.

I went through the test call-stack and found that the file which is used to test max memory is written before the the watcher is able to check the memory usage. Therefore the test fails.

The quickest solution is to add more chunks or increase chunk size so there will be enough time for the resource watcher to start and check system stats.

Playing with the chunk size is more of a workaround and not the actual fix, because the success rate of the test would highly depend on the machine, where tests are performed.