### PR TITLE
Add handling of garbage messages for controller socket

### DIFF
--- a/circus/controller.py
+++ b/circus/controller.py
@@ -126,7 +126,14 @@ class Controller(object):
         self.sys_hdl.stop()
 
     def handle_message(self, raw_msg):
-        cid, msg = raw_msg
+        try:
+            # Handle garbage messages,
+            # which are not originating from circus
+            cid, msg = raw_msg
+        except (TypeError, ValueError):
+            logger.warning("got unexpected message %s", raw_msg)
+            return
+
         msg = msg.strip()
 
         if not msg:

--- a/circus/tests/test_controller.py
+++ b/circus/tests/test_controller.py
@@ -71,5 +71,26 @@ class TestController(TestCase):
             controller._init_multicast_endpoint()
             self.assertTrue(mock_logger_warn.called)
 
+    def test_garbage_message(self):
+        class MockedController(Controller):
+            called = False
+
+            def dispatch(self, job, future=None):
+                self.called = True
+
+            def send_response(self, mid, cid, msg, resp, cast=False):
+                self.called = True
+
+        arbiter = mock.MagicMock()
+        loop = mock.MagicMock()
+        context = mock.sentinel.context
+        controller = MockedController('endpoint', 'multicast_endpoint',
+                                      context, loop, arbiter)
+        controller.handle_message(b'hello')
+        self.assertFalse(controller.called)
+        controller.handle_message([b'383ec229eb5d47f7bdd470dd3d6734a3',
+                                   b'{"command":"add", "foo": "bar"}'])
+        self.assertTrue(controller.called)
+
 
 test_suite = EasyTestSuite(__name__)


### PR DESCRIPTION
Fixes #1018 and closes #1019.

**Disclaimer**: all credit for this feature goes to @cgarciaarano. I am just expanding it a bit with a test.

The idea is that the "attacker" will be able to send malicious data over exposed controller socket and possibly overflow the machine and make it hang.

The test is straightforward: we are good if either `dispatch` or `send_response` methods were not called.