### PR TITLE
Fix Popen stdout and stderr arguments

### DIFF
--- a/circus/process.py
+++ b/circus/process.py
@@ -11,7 +11,7 @@ except ImportError:
 import sys
 import errno
 import os
-from subprocess import PIPE
+from subprocess import PIPE, DEVNULL
 import time
 import shlex
 import warnings
@@ -354,9 +354,13 @@ class Process(object):
         extra = {}
         if self.pipe_stdout:
             extra['stdout'] = PIPE
+        else:
+            extra['stdout'] = DEVNULL
 
         if self.pipe_stderr:
             extra['stderr'] = PIPE
+        else:
+            extra['stderr'] = DEVNULL
 
         self._worker = Popen(args, cwd=self.working_dir,
                              shell=self.shell, preexec_fn=preexec_fn,


### PR DESCRIPTION
For some reason, when using python3 circus, a python3 script can't be started in Popen() as used in the circus unless we specify the stdout and stderr as DEVNULL

This is the config not working:

```
[watcher:param_server_simulation]
cmd = /usr/bin/python3 /beyond/bazel-bin/modules/py_module/param_server/param_server -s
autostart = False
copy_env = True
```

The process ends up killed before it starts. This is worked around by defining a stdout_stream.class = FileStream. This config is working with the original circus code:
```
[watcher:param_server_simulation]
cmd = /usr/bin/python3 /beyond/bazel-bin/modules/py_module/param_server/param_server -s
autostart = False
copy_env = True

stdout_stream.class = FileStream
stdout_stream.filename = /tmp/out.log
stdout_stream.time_format = %Y-%m-%d %H:%M:%S
stdout_stream.max_bytes = 1073741824
stdout_stream.backup_count = 5
```

Not clear why this started happening with python3. It was not an issue with python2. Setting the stdout and stderr arguments explicitly to DEVNULL in Popen() resolves the issue.



