### PR TITLE
Remove io_loop argument when creating AsyncHTTPClient

### DIFF
--- a/circus/plugins/http_observer.py
+++ b/circus/plugins/http_observer.py
@@ -13,7 +13,8 @@ class HttpObserver(BaseObserver):
 
     def __init__(self, *args, **config):
         super(HttpObserver, self).__init__(*args, **config)
-        self.http_client = AsyncHTTPClient(io_loop=self.loop)
+        self.loop.make_current()
+        self.http_client = AsyncHTTPClient()
         self.check_url = config.get("check_url", "http://localhost/")
         self.timeout = float(config.get("timeout", 10))
 


### PR DESCRIPTION
The io_loop argument has been removed since Tornado v5
Attempting to fix #1165