### PR TITLE
warn when numprocesses is set to 0

### DIFF
--- a/circus/watcher.py
+++ b/circus/watcher.py
@@ -1099,6 +1099,8 @@ class Watcher(object):
             if self.singleton and val > 1:
                 raise ValueError('Singleton watcher has a single process')
             self.numprocesses = val
+            if int(self.numprocesses) == 0 and not self.singleton:
+                logger.warning('watcher numprocess=0, %s will not start', self.name)
         elif key == "warmup_delay":
             self.warmup_delay = float(val)
         elif key == "working_dir":


### PR DESCRIPTION
In some cases we want to generate circus configuration file based on the running environment, set numprocesses = f'{os.CPU_COUNT - 1}', If we generate this configuration file on a one-core server, numprocesses will be set to 0, and there will be no watcher process started, but no information supplied.

add a warn message will supply the user more useful information to resolve this type of issue.