### PR TITLE
fix ci issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ parts/*
 *.un~
 *.swp
 .pc
+.idea

--- a/circus/tests/support.py
+++ b/circus/tests/support.py
@@ -23,7 +23,7 @@ from circus import get_arbiter
 from circus.client import AsyncCircusClient, make_message
 from circus.util import DEFAULT_ENDPOINT_DEALER, DEFAULT_ENDPOINT_SUB
 from circus.util import tornado_sleep, ConflictError
-from circus.util import IS_WINDOWS
+from circus.util import IS_WINDOWS, IS_MACOS
 from circus.watcher import Watcher
 
 DEBUG = sysconfig.get_config_var('Py_DEBUG') == 1

--- a/circus/tests/test_config.py
+++ b/circus/tests/test_config.py
@@ -1,5 +1,6 @@
 import os
 import signal
+from unittest import skipIf
 from unittest.mock import patch
 
 from circus import logger
@@ -8,7 +9,7 @@ from circus.config import get_config
 from circus.watcher import Watcher
 from circus.process import Process
 from circus.sockets import CircusSocket
-from circus.tests.support import TestCase, EasyTestSuite, IS_WINDOWS
+from circus.tests.support import TestCase, EasyTestSuite, IS_WINDOWS, IS_MACOS
 from circus.util import replace_gnu_args, configure_logger
 
 
@@ -392,6 +393,7 @@ class TestConfig(TestCase):
         watcher = Watcher.load_from_config(conf['watchers'][0])
         watcher.stop()
 
+    @skipIf(IS_MACOS, "No test for syslog on macOS")
     def test_syslog_configuration(self):
         # this test will fail, if the syslog formatter is configured incorrectly
         configure_logger(None, output='syslog://localhost:514?test')

--- a/circus/tests/test_plugin_resource_watcher.py
+++ b/circus/tests/test_plugin_resource_watcher.py
@@ -127,7 +127,7 @@ class TestResourceWatcher(TestCircus):
     def test_resource_watcher_max_cpu(self):
         yield self.start_arbiter(fqn)
         yield async_poll_for(self.test_file, 'START')
-        config = {'loop_rate': 0.1, 'max_cpu': 0.1, 'watcher': 'test'}
+        config = {'loop_rate': 0.1, 'max_cpu': 0.001, 'watcher': 'test'}
         kw = {'endpoint': self.arbiter.endpoint,
               'pubsub_endpoint': self.arbiter.pubsub_endpoint}
 

--- a/circus/tests/test_validate_option.py
+++ b/circus/tests/test_validate_option.py
@@ -17,27 +17,34 @@ class TestValidateOption(TestCase):
 
     @patch('warnings.warn')
     def test_stdout_stream(self, warn):
+        key = 'stdout_stream'
         self.assertRaises(
-            MessageError, validate_option, 'stdout_stream', 'something')
-        self.assertRaises(MessageError, validate_option, 'stdout_stream', {})
-        validate_option('stdout_stream', {'class': 'MyClass'})
+            MessageError, validate_option, key, 'something')
+        self.assertRaises(MessageError, validate_option, key, {})
+        validate_option(key, {'class': 'MyClass'})
         validate_option(
-            'stdout_stream', {'class': 'MyClass', 'my_option': '1'})
+            key, {'class': 'MyClass', 'my_option': '1'})
         validate_option(
-            'stdout_stream', {'class': 'MyClass', 'refresh_time': 1})
-        self.assertEqual(warn.call_count, 1)
+            key, {'class': 'MyClass', 'refresh_time': 1})
+
+        msg = "'refresh_time' is deprecated and not useful anymore for %r" % key
+        warn.assert_any_call(msg)
 
     @patch('warnings.warn')
     def test_stderr_stream(self, warn):
+        key = 'stderr_stream'
         self.assertRaises(
-            MessageError, validate_option, 'stderr_stream', 'something')
-        self.assertRaises(MessageError, validate_option, 'stderr_stream', {})
-        validate_option('stderr_stream', {'class': 'MyClass'})
+            MessageError, validate_option, key, 'something')
+        self.assertRaises(MessageError, validate_option, key, {})
+
+        validate_option(key, {'class': 'MyClass'})
         validate_option(
-            'stderr_stream', {'class': 'MyClass', 'my_option': '1'})
+            key, {'class': 'MyClass', 'my_option': '1'})
         validate_option(
-            'stderr_stream', {'class': 'MyClass', 'refresh_time': 1})
-        self.assertEqual(warn.call_count, 1)
+            key, {'class': 'MyClass', 'refresh_time': 1})
+
+        msg = "'refresh_time' is deprecated and not useful anymore for %r" % key
+        warn.assert_any_call(msg)
 
     def test_hooks(self):
         validate_option('hooks', {'before_start': ['all', False]})

--- a/circus/util.py
+++ b/circus/util.py
@@ -2,6 +2,7 @@ import functools
 import logging
 import logging.config
 import os
+import platform
 import re
 import shlex
 import socket
@@ -97,6 +98,7 @@ _SYMBOLS = ('K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y')
 _all_signals = {}
 
 IS_WINDOWS = os.name == 'nt'
+IS_MACOS = platform.uname()[0] == 'Darwin'
 
 
 def get_working_dir():


### PR DESCRIPTION
The CI red x looks ugly, I fix it by:


1. test_syslog_configuration in test_config.py will sometimes block test_papa_stream on macOS, so skip it on macOS.

2. test_stderr_stream and test_stdout_stream in circus/tests/test_validate_option.py should just make sure warn just called with the expected argument to avoid infected by other module's warn call. (use mock.assert_xxxx to get more detail information when bad things happened)

3. change test_resource_watcher_max_cpu max_cpu to 0.001 to be more deterministic. 