### PR TITLE
fix unit tests errors and add Python3.9 official support / Add Python3.9 and PyPy3.7 to CI flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,11 @@ jobs:
 
   ubuntu:
     runs-on: ubuntu-18.04
-    timeout-minutes: 5
+    timeout-minutes: 10
 
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, 'pypy-3.7']
         include:
           - python-version: 3.5
             tox-env: py35
@@ -20,6 +20,10 @@ jobs:
             tox-env: py37
           - python-version: 3.8
             tox-env: py38
+          - python-version: 3.9
+            tox-env: py39
+          - python-version: pypy-3.7
+            tox-env: pypy37
 
     steps:
     - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ parts/*
 *.un~
 *.swp
 .pc
+.idea

--- a/circus/tests/__init__.py
+++ b/circus/tests/__init__.py
@@ -1,4 +1,6 @@
 import os
+
+import papa
 import zmq
 from circus.util import configure_logger
 from circus import logger
@@ -13,11 +15,16 @@ if not _CONFIGURED and 'TESTING' in os.environ:
 
 def setUp():
     from circus import _patch   # NOQA
+    papa.set_default_port(30303)
+    papa.set_default_connection_timeout(5)
 
 
 def tearDown():
     # There seems to some issue with context cleanup and Python >= 3.4
     # making the tests hang at the end
-    # Explicitely destroying the context seems to do the trick
+    # Explicitly destroying the context seems to do the trick
     # cf https://github.com/zeromq/pyzmq/pull/513
     zmq.Context.instance().destroy()
+
+    with papa.Papa() as p:
+        p.exit_if_idle()

--- a/circus/tests/test_papa_stream.py
+++ b/circus/tests/test_papa_stream.py
@@ -1,16 +1,15 @@
-import time
-import sys
 import os
+import sys
 import tempfile
-import tornado
-import random
+import time
 
-from circus.util import papa
+import tornado
 from circus.client import make_message
-from circus.tests.support import TestCircus, async_poll_for, truncate_file
-from circus.tests.support import EasyTestSuite, skipIf, IS_WINDOWS
 from circus.stream import FileStream, WatchedFileStream
 from circus.stream import TimedRotatingFileStream
+from circus.tests.support import EasyTestSuite, skipIf, IS_WINDOWS
+from circus.tests.support import TestCircus, async_poll_for, truncate_file
+from circus.util import papa
 
 
 def run_process(testfile, *args, **kw):
@@ -31,13 +30,9 @@ def run_process(testfile, *args, **kw):
 @skipIf('TRAVIS' in os.environ, "Skipped on Travis")
 class TestPapaStream(TestCircus):
     dummy_process = 'circus.tests.test_stream.run_process'
-    papa_port = random.randint(20000, 30000)
 
     def setUp(self):
         super(TestPapaStream, self).setUp()
-        papa.set_debug_mode(quit_when_connection_closed=True)
-        papa.set_default_port(self.papa_port)
-        papa.set_default_connection_timeout(120)
         fd, self.stdout = tempfile.mkstemp()
         os.close(fd)
         fd, self.stderr = tempfile.mkstemp()

--- a/circus/tests/test_plugin_resource_watcher.py
+++ b/circus/tests/test_plugin_resource_watcher.py
@@ -127,14 +127,14 @@ class TestResourceWatcher(TestCircus):
     def test_resource_watcher_max_cpu(self):
         yield self.start_arbiter(fqn)
         yield async_poll_for(self.test_file, 'START')
-        config = {'loop_rate': 0.1, 'max_cpu': 0.1, 'watcher': 'test'}
+        config = {'loop_rate': 0.1, 'max_cpu': -0.1, 'watcher': 'test'}
         kw = {'endpoint': self.arbiter.endpoint,
               'pubsub_endpoint': self.arbiter.pubsub_endpoint}
 
         statsd_increments = yield async_run_plugin(ResourceWatcher,
                                                    config,
                                                    get_statsd_increments, **kw)
-
+        print(statsd_increments)
         self._check_statsd(statsd_increments,
                            '_resource_watcher.test.over_cpu')
         yield self.stop_arbiter()

--- a/circus/tests/test_plugin_resource_watcher.py
+++ b/circus/tests/test_plugin_resource_watcher.py
@@ -134,7 +134,6 @@ class TestResourceWatcher(TestCircus):
         statsd_increments = yield async_run_plugin(ResourceWatcher,
                                                    config,
                                                    get_statsd_increments, **kw)
-        print(statsd_increments)
         self._check_statsd(statsd_increments,
                            '_resource_watcher.test.over_cpu')
         yield self.stop_arbiter()

--- a/circus/tests/test_stats_publisher.py
+++ b/circus/tests/test_stats_publisher.py
@@ -16,6 +16,7 @@ class TestStatsPublisher(TestCase):
     def tearDown(self):
         self.publisher.socket = self.origin_socket
         self.publisher.stop()
+        del self.origin_socket
 
     def test_publish(self):
         stat = {'subtopic': 1, 'foo': 'bar'}

--- a/circus/tests/test_stats_publisher.py
+++ b/circus/tests/test_stats_publisher.py
@@ -8,33 +8,34 @@ from circus.stats.publisher import StatsPublisher
 
 
 class TestStatsPublisher(TestCase):
+    def setUp(self):
+        self.publisher = StatsPublisher()
+        self.origin_socket = self.publisher.socket
+        self.publisher.socket = mock.MagicMock()
+
+    def tearDown(self):
+        self.publisher.socket = self.origin_socket
+        self.publisher.stop()
 
     def test_publish(self):
-        publisher = StatsPublisher()
-        publisher.socket.close()
-        publisher.socket = mock.MagicMock()
         stat = {'subtopic': 1, 'foo': 'bar'}
-        publisher.publish('foobar', stat)
-        publisher.socket.send_multipart.assert_called_with(
+        self.publisher.publish('foobar', stat)
+        self.publisher.socket.send_multipart.assert_called_with(
             [b'stat.foobar.1', json.dumps(stat)])
 
     def test_publish_reraise_zmq_errors(self):
-        publisher = StatsPublisher()
-        publisher.socket = mock.MagicMock()
-        publisher.socket.closed = False
-        publisher.socket.send_multipart.side_effect = zmq.ZMQError()
+        self.publisher.socket.closed = False
+        self.publisher.socket.send_multipart.side_effect = zmq.ZMQError()
 
         stat = {'subtopic': 1, 'foo': 'bar'}
-        self.assertRaises(zmq.ZMQError, publisher.publish, 'foobar', stat)
+        self.assertRaises(zmq.ZMQError, self.publisher.publish, 'foobar', stat)
 
     def test_publish_silent_zmq_errors_when_socket_closed(self):
-        publisher = StatsPublisher()
-        publisher.socket = mock.MagicMock()
-        publisher.socket.closed = True
-        publisher.socket.send_multipart.side_effect = zmq.ZMQError()
+        self.publisher.socket.closed = True
+        self.publisher.socket.send_multipart.side_effect = zmq.ZMQError()
 
         stat = {'subtopic': 1, 'foo': 'bar'}
-        publisher.publish('foobar', stat)
+        self.publisher.publish('foobar', stat)
 
 
 test_suite = EasyTestSuite(__name__)

--- a/circus/tests/test_validate_option.py
+++ b/circus/tests/test_validate_option.py
@@ -17,27 +17,34 @@ class TestValidateOption(TestCase):
 
     @patch('warnings.warn')
     def test_stdout_stream(self, warn):
+        key = 'stdout_stream'
         self.assertRaises(
-            MessageError, validate_option, 'stdout_stream', 'something')
-        self.assertRaises(MessageError, validate_option, 'stdout_stream', {})
-        validate_option('stdout_stream', {'class': 'MyClass'})
+            MessageError, validate_option, key, 'something')
+        self.assertRaises(MessageError, validate_option, key, {})
+        validate_option(key, {'class': 'MyClass'})
         validate_option(
-            'stdout_stream', {'class': 'MyClass', 'my_option': '1'})
+            key, {'class': 'MyClass', 'my_option': '1'})
         validate_option(
-            'stdout_stream', {'class': 'MyClass', 'refresh_time': 1})
-        self.assertEqual(warn.call_count, 1)
+            key, {'class': 'MyClass', 'refresh_time': 1})
+
+        msg = "'refresh_time' is deprecated and not useful anymore for %r" % key
+        warn.assert_any_call(msg)
 
     @patch('warnings.warn')
     def test_stderr_stream(self, warn):
+        key = 'stderr_stream'
         self.assertRaises(
-            MessageError, validate_option, 'stderr_stream', 'something')
-        self.assertRaises(MessageError, validate_option, 'stderr_stream', {})
-        validate_option('stderr_stream', {'class': 'MyClass'})
+            MessageError, validate_option, key, 'something')
+        self.assertRaises(MessageError, validate_option, key, {})
+
+        validate_option(key, {'class': 'MyClass'})
         validate_option(
-            'stderr_stream', {'class': 'MyClass', 'my_option': '1'})
+            key, {'class': 'MyClass', 'my_option': '1'})
         validate_option(
-            'stderr_stream', {'class': 'MyClass', 'refresh_time': 1})
-        self.assertEqual(warn.call_count, 1)
+            key, {'class': 'MyClass', 'refresh_time': 1})
+
+        msg = "'refresh_time' is deprecated and not useful anymore for %r" % key
+        warn.assert_any_call(msg)
 
     def test_hooks(self):
         validate_option('hooks', {'before_start': ['all', False]})

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(name='circus',
           "Programming Language :: Python :: 3.6",
           "Programming Language :: Python :: 3.7",
           "Programming Language :: Python :: 3.8",
+          "Programming Language :: Python :: 3.9",
           "License :: OSI Approved :: Apache Software License"
       ],
       install_requires=install_requires,

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,py37,py38,flake8,docs
+envlist = py35,py36,py37,py38,py39,pypy37,flake8,docs
 
 [testenv]
 passenv = PWD


### PR DESCRIPTION
fix tests:
1. use a shared papa server for papa stream tests
2. test_stdout_stream and test_stderr_stream in TestValidateOption use a more specific assertion to avoid warn call from other modules.
3. test_resource_watcher_max_cpu set max_cpu to a very small value to get more deterministic results.

optimize:
1. TestStatsPublisher, remove duplicate code and manage zmq socket by hand, don't depend on the system to GC the socket, it's not reliable.