### PR TITLE
add pypy38 to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,17 +5,13 @@ on: [push, pull_request]
 jobs:
 
   ubuntu:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 10
 
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, 'pypy-3.7']
+        python-version: [3.7, 3.8, 3.9, 'pypy-3.7', 'pypy-3.8']
         include:
-          - python-version: 3.5
-            tox-env: py35
-          - python-version: 3.6
-            tox-env: py36
           - python-version: 3.7
             tox-env: py37
           - python-version: 3.8
@@ -24,6 +20,8 @@ jobs:
             tox-env: py39
           - python-version: pypy-3.7
             tox-env: pypy37
+          - python-version: pypy-3.8
+            tox-env: pypy38
 
     steps:
     - uses: actions/checkout@v2
@@ -38,6 +36,8 @@ jobs:
         sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
         sudo apt update
         sudo apt install libev-dev libevent-dev
+        sudo apt install gcc make libffi-dev pkg-config zlib1g-dev libbz2-dev libsqlite3-dev libncurses5-dev libexpat1-dev libssl-dev libgdbm-dev tk-dev libgc-dev python-cffi liblzma-dev libncursesw5-dev
+        sudo ldconfig
     - name: Install test dependencies
       run: |
         pip install tox coveralls

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,6 @@ setup(name='circus',
       zip_safe=False,
       classifiers=[
           "Programming Language :: Python",
-          "Programming Language :: Python :: 3.5",
-          "Programming Language :: Python :: 3.6",
           "Programming Language :: Python :: 3.7",
           "Programming Language :: Python :: 3.8",
           "Programming Language :: Python :: 3.9",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,py37,py38,py39,pypy37,flake8,docs
+envlist = py37,py38,py39,pypy37,pypy38,flake8,docs
 
 [testenv]
 passenv = PWD


### PR DESCRIPTION
1. Add  PyPy38 to CI which requires Ubuntu upgrade to 20.04 to use latest binary dependencies that PyPy38 need;
2. Drop Python 3.5 and Python 3.6 from official support and CI.

NOTE: there seems to be some test case's result is not deterministic, I'll try to find out the root cause and fix it.