### PR TITLE
Remove circus-web dependency from tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,6 @@ deps =
     nose-cov
     coverage
     mock
-    circus-web
     gevent
     papa
     PyYAML


### PR DESCRIPTION
Remove circus-web dependency from tox.ini.

circus-web depends on a library called anyjson which cannot be installed with new version of setuptools, and anyjson is no longer maintained.

and circus-web is not used in the tests, so it should be removed.