### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(name='circus',
       author="Mozilla Foundation & contributors",
       author_email="services-dev@lists.mozila.org",
       project_urls={
-          "Documentation": "https://circus.readthedocs.io/en/latest/",
+          "Documentation": "https://circus.readthedocs.io",
           "Source": "https://github.com/circus-tent/circus",
       },
       include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,10 @@ setup(name='circus',
       long_description_content_type="text/markdown",
       author="Mozilla Foundation & contributors",
       author_email="services-dev@lists.mozila.org",
+      project_urls={
+          "Documentation": "https://circus.readthedocs.io/en/latest/",
+          "Source": "https://github.com/circus-tent/circus",
+      },
       include_package_data=True,
       zip_safe=False,
       classifiers=[


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)