### PR TITLE
Dependencies: Add support for Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, 'pypy-3.7', 'pypy-3.8']
+        python-version: ['3.7', '3.8', '3.9', '3.10', 'pypy-3.7', 'pypy-3.8']
         include:
-          - python-version: 3.7
+          - python-version: '3.7'
             tox-env: py37
-          - python-version: 3.8
+          - python-version: '3.8'
             tox-env: py38
-          - python-version: 3.9
+          - python-version: '3.9'
             tox-env: py39
+          - python-version: '3.10'
+            tox-env: py310
           - python-version: pypy-3.7
             tox-env: pypy37
           - python-version: pypy-3.8
@@ -40,8 +42,7 @@ jobs:
         sudo apt install gcc make libffi-dev pkg-config zlib1g-dev libbz2-dev libsqlite3-dev libncurses5-dev libexpat1-dev libssl-dev libgdbm-dev tk-dev libgc-dev python-cffi liblzma-dev libncursesw5-dev
         sudo ldconfig
     - name: Install test dependencies
-      run: |
-        pip install tox coveralls
+      run: pip install tox coveralls
     - name: Run test suite
       run: tox -v -e $TOX_ENV
       env:
@@ -68,7 +69,7 @@ jobs:
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: '3.8'
 
     - name: Install test dependencies
       run: |

--- a/circus/tests/test_papa_stream.py
+++ b/circus/tests/test_papa_stream.py
@@ -28,6 +28,7 @@ def run_process(testfile, *args, **kw):
 
 @skipIf(papa is None, "papa not available")
 @skipIf('TRAVIS' in os.environ, "Skipped on Travis")
+@skipIf(sys.version_info[:2] >= (3, 10), "`papa` is not compatible with Python 3.10")
 class TestPapaStream(TestCircus):
     dummy_process = 'circus.tests.test_stream.run_process'
 

--- a/circus/tests/test_util.py
+++ b/circus/tests/test_util.py
@@ -280,7 +280,7 @@ class TestUtil(TestCase):
         # we want virtualenv directory to contain a site-packages
         self.assertRaises(ValueError, load_virtualenv, watcher)
 
-        py_ver = sys.version.split()[0][:3]
+        py_ver = "%s.%s" % sys.version_info[:2]
         site_pkg = os.path.join(watcher.virtualenv, 'lib',
                                 'python%s' % py_ver, 'site-packages')
         os.makedirs(site_pkg)
@@ -301,7 +301,7 @@ class TestUtil(TestCase):
 
         # test with a pypy virtual environment
         watcher.env = {}
-        py_ver = sys.version.split()[0][:3]
+        py_ver = "%s.%s" % sys.version_info[:2]
         site_pkg_pypy = os.path.join(watcher.virtualenv, 'lib',
                                      'pypy%s' % py_ver, 'site-packages')
 

--- a/circus/tests/venv/lib/python3.10/orig-prefix.txt
+++ b/circus/tests/venv/lib/python3.10/orig-prefix.txt
@@ -1,0 +1,1 @@
+/Library/Frameworks/Python.framework/Versions/3.10

--- a/circus/tests/venv/lib/python3.10/site-packages/easy-install.pth
+++ b/circus/tests/venv/lib/python3.10/site-packages/easy-install.pth
@@ -1,0 +1,3 @@
+import sys; sys.__plen = len(sys.path)
+./pip-7.7-py3.10.egg
+import sys; new=sys.path[sys.__plen:]; del sys.path[sys.__plen:]; p=getattr(sys,'__egginsert',0); sys.path[p:p]=new; sys.__egginsert = p+len(new)

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@ import sys
 from circus import __version__
 from setuptools import find_packages, setup
 
-if not hasattr(sys, 'version_info') or sys.version_info < (3, 5, 0, 'final'):
-    raise SystemExit("Circus requires Python 3.5 or higher.")
+if not hasattr(sys, 'version_info') or sys.version_info < (3, 7, 0, 'final'):
+    raise SystemExit("Circus requires Python 3.7 or higher.")
 
 
 install_requires = ['psutil', 'pyzmq>=17.0', 'tornado>=5.0.2']
@@ -38,6 +38,7 @@ setup(name='circus',
           "Programming Language :: Python :: 3.7",
           "Programming Language :: Python :: 3.8",
           "Programming Language :: Python :: 3.9",
+          "Programming Language :: Python :: 3.10",
           "License :: OSI Approved :: Apache Software License"
       ],
       install_requires=install_requires,


### PR DESCRIPTION
Add Python 3.10 to the matrix of the CI workflow. All Python version numbers are properly wrapped in strings, otherwise they are interpreted as floats and `3.10` will become `3.1`.

The `setup.py` is updated to officially record support of Python 3.10 and the check for the minimum requirement is updated to actually check for Python 3.7, it was mistakenly still checking for Python 3.5.

Finally, the tests for the `papa` optional dependency are disabled because `papa` is not compatible with Python 3.10. It seems the project has been abandoned as the latest officially supported version is Python 3.4 and the last release was in early 2016.