### PR TITLE
DevOps: Update version of MacOS runners to `macos-12`

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -74,7 +74,7 @@ jobs:
 
         strategy:
             matrix:
-                os: ['macos-10.15']
+                os: ['macos-12']
                 skip-tests: [false]
                 include:
                 -   os: windows-2019

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
 
     strategy:
       matrix:
-        os: ['macos-10.15']
+        os: ['macos-12']
         skip-tests: [false]
         include:
           - os: windows-2019


### PR DESCRIPTION
The `macos-10.15` runner has been deprecated and will be removed on December 22. The workflows have been getting cancelled on these runners.