### PR TITLE
DevOps: Fix the trove classifiers in the `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,10 +12,10 @@ readme = 'README.md'
 license = {file = 'LICENSE'}
 classifiers = [
     'Development Status :: 5 - Production/Stable',
-    'License :: OSI Approved :: Apache Software License"',
+    'License :: OSI Approved :: Apache Software License',
     'Operating System :: POSIX :: Linux',
     'Operating System :: MacOS :: MacOS X',
-    'Operating System :: POSIX :: Windows',
+    'Operating System :: Microsoft :: Windows',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',


### PR DESCRIPTION
There were two invalid trove classifiers:

    Operating System :: POSIX :: Windows

should be:

    Operating System :: Microsoft :: Windows

And the license classifier had a trailing double quote. These mistakes were raised by `flit` when trying to publish the package. Valid
classifiers are provided by: https://pypi.org/classifiers/