### PR TITLE
DevOps: Address deprecation warnings 

### DIFF
--- a/circus/tests/config/reload_statsd.ini
+++ b/circus/tests/config/reload_statsd.ini
@@ -3,6 +3,7 @@ check_delay = -1
 endpoint = tcp://127.0.0.1:7555
 pubsub_endpoint = tcp://127.0.0.1:7556
 stats_endpoint = tcp://127.0.0.1:5557
+statsd = True
 
 [watcher:test1]
 cmd = sleep 120

--- a/circus/tests/config/reuseport.ini
+++ b/circus/tests/config/reuseport.ini
@@ -3,6 +3,7 @@ check_delay = 5
 endpoint = tcp://127.0.0.1:5555
 pubsub_endpoint = tcp://127.0.0.1:5556
 stats_endpoint = tcp://127.0.0.1:5557
+statsd = True
 
 [socket:reuseport]
 host = 127.0.0.1

--- a/circus/tests/test_stdin_socket.py
+++ b/circus/tests/test_stdin_socket.py
@@ -7,7 +7,6 @@ from circus.tests.support import TestCircus, TimeoutException
 from circus.tests.support import skipIf, IS_WINDOWS
 from circus.stream import QueueStream, Empty
 from circus.util import tornado_sleep
-from zmq.utils.strtypes import u
 from circus.sockets import CircusSocket
 
 
@@ -25,7 +24,7 @@ def read_from_stream(stream, timeout=5):
     while time.time() - start < timeout:
         try:
             data = stream.get_nowait()
-            raise tornado.gen.Return(u(data['data']))
+            raise tornado.gen.Return(data['data'].decode('utf-8'))
         except Empty:
             yield tornado_sleep(.1)
     raise TimeoutException('Timeout reading queue')

--- a/circus/tests/test_umask.py
+++ b/circus/tests/test_umask.py
@@ -8,7 +8,6 @@ from circus.tests.support import TestCircus, EasyTestSuite, TimeoutException
 from circus.tests.support import skipIf, IS_WINDOWS
 from circus.stream import QueueStream, Empty
 from circus.util import tornado_sleep
-from zmq.utils.strtypes import u
 
 
 class Process(object):
@@ -53,7 +52,7 @@ def read_from_stream(stream, timeout=5):
     while time.time() - start < timeout:
         try:
             data = stream.get_nowait()
-            raise tornado.gen.Return(u(data['data']))
+            raise tornado.gen.Return(data['data'].decode('utf-8'))
         except Empty:
             yield tornado_sleep(0.1)
     raise TimeoutException('Timeout reading queue')

--- a/circus/util.py
+++ b/circus/util.py
@@ -39,7 +39,7 @@ from urllib.parse import urlparse
 from datetime import timedelta
 from functools import wraps
 import signal
-from pipes import quote as shell_escape_arg
+from shlex import quote as shell_escape_arg
 
 try:
     import importlib


### PR DESCRIPTION
 * `pipes` module of standard library is replaced with `shlex`
 * `pyzmq.utils.strtypes` was compatibility layer for Python 2 and 3.
   The `u` method was to convert to unicode but this is no longer
   applicable in Python 3 so can be removed.
 * Address internal deprecation warnings of `statsd` not being set to
   `True` in the config if a stats endpoint is defined.

The only warnings remaining is with respect to the misuse of event loops through `tornado`. However, this is more tricky to fix and would probably involve a bigger refactor, potentially even removing `tornado` altogether as now it is mostly a wrapper around `asyncio` of the standard library.