### PR TITLE
Change rollover interval `midnight` in docs to `MIDNIGHT`

### DIFF
--- a/circus/stream/file_stream.py
+++ b/circus/stream/file_stream.py
@@ -218,7 +218,7 @@ class TimedRotatingFileStream(FileStream):
         - utc: if True, times in UTC will be used. otherwise local time is
           used. Default: False.
         - rotate_when: the type of interval. Can be S, M, H, D,
-          'W0'-'W6' or 'midnight'. See Python's TimedRotatingFileHandler
+          'W0'-'W6' or 'MIDNIGHT'. See Python's TimedRotatingFileHandler
           for more information.
         - rotate_interval: Rollover interval in seconds. Default: 1
 

--- a/docs/source/for-ops/configuration.rst
+++ b/docs/source/for-ops/configuration.rst
@@ -697,7 +697,7 @@ TimedRotatingFileStream
             'H', Hours
             'D', Days
             'W0'-'W6', Weekday (0=Monday)
-            'midnight', Roll over at midnight
+            'MIDNIGHT', Roll over at midnight
 
     **rotate_interval**
         The rollover interval.


### PR DESCRIPTION
When specifying log rotation at midnight when using the `TimedRotatingFileStream` class, the docs indicate that `rotate_when` should be `midnight`, when in fact it should be `MIDNIGHT` (as the code actually expects the string "MIDNIGHT" in this case).