### PR TITLE
Release 0.19.0

### DIFF
--- a/circus/__init__.py
+++ b/circus/__init__.py
@@ -4,7 +4,7 @@ import os
 import warnings
 
 
-version_info = (0, 18, 0)
+version_info = (0, 19, 0)
 __version__ = ".".join(map(str, version_info))
 
 # This config call is done to avoid any

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,23 @@
 Changelog history
 =================
 
+0.19.0 2025-02-10
+-----------------
+
+Dependencies
+............
+Address deprecation warnings regarding `pipes`, `pyzmq.utils.strtypes` and `statsd` [[#1211]](https://github.com/circus-tent/circus/pull/1211)
+Add support for Python 3.12 and 3.13 [[#1222]](https://github.com/circus-tent/circus/pull/1222)
+
+DevOps
+......
+Update version of MacOS runners to `macos-12` [[#1208]](https://github.com/circus-tent/circus/pull/1208)
+Fix the trove classifiers in the `pyproject.toml` [[#1209]](https://github.com/circus-tent/circus/pull/1209)
+Replace `nose` with `pytest` to run unit tests [[#1210]](https://github.com/circus-tent/circus/pull/1221)
+Move `tests` directory outside of `circus` package [[#1206]](https://github.com/circus-tent/circus/pull/1206)
+Fixes for failing CI [[#1218]](https://github.com/circus-tent/circus/pull/1218)
+Add Python 3.12 and 3.13 to CI [[#1221]](https://github.com/circus-tent/circus/pull/1221)
+
 0.18.0 2022-11-17
 -----------------
 


### PR DESCRIPTION
This PR is based on PR #1222

I think the same logic as in  Release v0.18.0 #1207 goes

> @biozz I bumped the minor version since we are removing support for `papa` but since we are still pre v1.0, we "technically" could just go with `0.17.3` instead. Would be fine for me as well.

_Originally posted by @sphuber in https://github.com/circus-tent/circus/issues/1207#issuecomment-1318792890_

So technically this could be a 0.18.1 release, but since in that PR a new major release was used I just imitated it.